### PR TITLE
REGISTRY-2624 Fix. Avoiding jasper-jdt from packing with reporting fe…

### DIFF
--- a/features/reporting/org.wso2.carbon.reporting.server.feature/pom.xml
+++ b/features/reporting/org.wso2.carbon.reporting.server.feature/pom.xml
@@ -111,7 +111,6 @@
                                 <bundleDef>commons-beanutils.wso2:commons-beanutils</bundleDef>
                                 <bundleDef>commons-digester.wso2:commons-digester</bundleDef>
                                 <bundleDef>jcommon.wso2:jcommon</bundleDef>
-                                <bundleDef>jasper-jdt.wso2:jasper-jdt</bundleDef>
                                 <bundleDef>jfree.wso2:jfreechart</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/reporting/org.wso2.carbon.reporting.template.ui.feature/pom.xml
+++ b/features/reporting/org.wso2.carbon.reporting.template.ui.feature/pom.xml
@@ -91,7 +91,6 @@
                                 <importBundleDef>commons-beanutils.wso2:commons-beanutils</importBundleDef>
                                 <importBundleDef>commons-digester.wso2:commons-digester</importBundleDef>
                                 <importBundleDef>jcommon.wso2:jcommon</importBundleDef>
-                                <importBundleDef>jasper-jdt.wso2:jasper-jdt</importBundleDef>
                                 <importBundleDef>jfree.wso2:jfreechart</importBundleDef>
                             </importBundles>
                             <importFeatures>

--- a/features/reporting/org.wso2.carbon.reporting.ui.feature/pom.xml
+++ b/features/reporting/org.wso2.carbon.reporting.ui.feature/pom.xml
@@ -124,7 +124,6 @@
                                 <importBundleDef>commons-beanutils.wso2:commons-beanutils</importBundleDef>
                                 <importBundleDef>commons-digester.wso2:commons-digester</importBundleDef>
                                 <importBundleDef>jcommon.wso2:jcommon</importBundleDef>
-                                <importBundleDef>jasper-jdt.wso2:jasper-jdt</importBundleDef>
                                 <importBundleDef>jfree.wso2:jfreechart</importBundleDef>
                             </importBundles>
                             <importFeatures>


### PR DESCRIPTION
This is to avoid jasper-jdt getting packed from the reporting feature. This causes some issues in certain jsps in Java 8.

Please review and merge the fix if applicable.