### PR TITLE
fixing g-reg event subscription issue by modifying PR #99

### DIFF
--- a/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
+++ b/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
@@ -157,6 +157,10 @@ public class RegistryTopicManager implements TopicManager {
 
                 userRealm.getAuthorizationManager().authorizeUser(
                         loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_CHANGE_PERMISSION);
+                userRealm.getAuthorizationManager().authorizeUser(
+                        loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_PUBLISH);
+                userRealm.getAuthorizationManager().authorizeUser(
+                        loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_SUBSCRIBE);
             }
         } catch (RegistryException e) {
             throw new EventBrokerException("Cannot access the config registry", e);


### PR DESCRIPTION
When giving permission to logged in user in RegistryTopicManager#addTopic() we need to give publish and subscribe permissions too.