### PR TITLE
Removing org.wso2.carbon.um.ws.api.stub in event feature

### DIFF
--- a/features/event/org.wso2.carbon.event.ui.feature/pom.xml
+++ b/features/event/org.wso2.carbon.event.ui.feature/pom.xml
@@ -76,7 +76,6 @@
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.event.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.event.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.event.client.stub</bundleDef>
-                                <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.um.ws.api.stub</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core.ui:${carbon.kernel.version}</importFeatureDef>


### PR DESCRIPTION
- org.wso2.carbon.um.ws.api.stub bundle removed from org.wso2.carbon.event.ui.feature