### PR TITLE
[MB-1281] Fix error validation in event sink url

### DIFF
--- a/components/event/org.wso2.carbon.event.ui/src/main/resources/web/topics/add_subscription_ajaxprocessor.jsp
+++ b/components/event/org.wso2.carbon.event.ui/src/main/resources/web/topics/add_subscription_ajaxprocessor.jsp
@@ -51,7 +51,7 @@
 
         BrokerClient brokerClient = UIUtils.getBrokerClient(config, session, request);
         String message = "";
-        if (eventSink != null) {
+        if ((eventSink != null) && (eventSink != "")) {
             topic = topic.trim();
 
             String expirationDateTime = "";
@@ -71,14 +71,14 @@
             } catch (BrokerClientException e) {
                 message = e.getErrorMessage();
             } catch (ParseException e) {
-                message = "Expiration date/time(" + expirationDateTime + ") is invalid.";
+                message = "Error: Expiration date/time(" + expirationDateTime + ") is invalid.";
             }
 
 %>
 <%=message%>
 <%
 } else {
-    message = "Topic and Event Sink Must not be null";
+    message = "Error: Topic and Event Sink Must not be null";
 
 %>
 <%=message%>


### PR DESCRIPTION
Empty string propagates to back-end and exception thrown back to ui due to UI validation didn't handle empty strings.
In 'treecontrol.js' 'performSubscribe()' line424 error catches by searching response string for "Error:".
With this fix ui validation will catch empty strings from event sink url and throws response with "Error:" String.

jira - https://wso2.org/jira/browse/MB-1281