### PR TITLE
Esb anlaytic upgrade

### DIFF
--- a/components/event/org.wso2.carbon.event.admin/src/main/java/org/wso2/carbon/event/admin/internal/TopicManagerAdminService.java
+++ b/components/event/org.wso2.carbon.event.admin/src/main/java/org/wso2/carbon/event/admin/internal/TopicManagerAdminService.java
@@ -15,7 +15,6 @@ import java.util.Calendar;
 /**
  * Provides topic related functions as a web service.
  */
-@Deprecated
 public class TopicManagerAdminService {
 
     /**

--- a/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
+++ b/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
@@ -153,16 +153,18 @@ public class RegistryTopicManager implements TopicManager {
                 Collection collection = userRegistry.newCollection();
                 userRegistry.put(resourcePath, collection);
 
-                // Grant this user (owner) rights to update permission on newly created topic
-                UserRealm userRealm = EventBrokerHolder.getInstance().getRealmService().getTenantUserRealm(
-                        CarbonContext.getThreadLocalCarbonContext().getTenantId());
+                if (loggedInUser != null) {
+                    // Grant this user (owner) rights to update permission on newly created topic
+                    UserRealm userRealm = EventBrokerHolder.getInstance().getRealmService().getTenantUserRealm(
+                            CarbonContext.getThreadLocalCarbonContext().getTenantId());
 
-                userRealm.getAuthorizationManager().authorizeUser(
-                        loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_CHANGE_PERMISSION);
-                userRealm.getAuthorizationManager().authorizeUser(
-                        loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_PUBLISH);
-                userRealm.getAuthorizationManager().authorizeUser(
-                        loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_SUBSCRIBE);
+                    userRealm.getAuthorizationManager().authorizeUser(loggedInUser, resourcePath,
+                                                                      EventBrokerConstants.EB_PERMISSION_CHANGE_PERMISSION);
+                    userRealm.getAuthorizationManager()
+                             .authorizeUser(loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_PUBLISH);
+                    userRealm.getAuthorizationManager()
+                             .authorizeUser(loggedInUser, resourcePath, EventBrokerConstants.EB_PERMISSION_SUBSCRIBE);
+                }
             }
         } catch (RegistryException e) {
             throw new EventBrokerException("Cannot access the config registry", e);

--- a/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
+++ b/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/topic/registry/RegistryTopicManager.java
@@ -152,12 +152,10 @@ public class RegistryTopicManager implements TopicManager {
             if (!userRegistry.resourceExists(resourcePath)) {
                 Collection collection = userRegistry.newCollection();
                 userRegistry.put(resourcePath, collection);
-
                 if (loggedInUser != null) {
                     // Grant this user (owner) rights to update permission on newly created topic
                     UserRealm userRealm = EventBrokerHolder.getInstance().getRealmService().getTenantUserRealm(
                             CarbonContext.getThreadLocalCarbonContext().getTenantId());
-
                     userRealm.getAuthorizationManager().authorizeUser(loggedInUser, resourcePath,
                                                                       EventBrokerConstants.EB_PERMISSION_CHANGE_PERMISSION);
                     userRealm.getAuthorizationManager()


### PR DESCRIPTION
This fix has removed @Deprecated from service as it results in a runtime error. Then this fix also introduced fix (https://wso2.org/jira/browse/ESBJAVA-2506) that was given to 4.4.x version but not present in 4.5.x release. Without this fix https://github.com/wso2/product-esb/blob/master/modules/integration/tests-integration/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/rule/ESBJAVA2506RuleFetchFromRegistryFailsForTheFirstTime.java intergration test is getting failed.