### PR TITLE
guava update from 13.0 to 19.0

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.service/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava.wso2</groupId>
+            <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>

--- a/features/logging-mgt/org.wso2.carbon.logging.summarizer.server.feature/pom.xml
+++ b/features/logging-mgt/org.wso2.carbon.logging.summarizer.server.feature/pom.xml
@@ -42,7 +42,7 @@
 
 
        <dependency>
-            <groupId>com.google.guava.wso2</groupId>
+            <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
           <!--Hector-->
@@ -225,7 +225,7 @@
 				<bundleDef>org.wso2.carbon:org.wso2.carbon.analytics.hive</bundleDef>
                                 <bundleDef>antlr.wso2:antlr</bundleDef>
                                 <bundleDef>org.antlr.wso2:antlr-runtime</bundleDef>
-                                <bundleDef>com.google.guava.wso2:guava</bundleDef>
+                                <bundleDef>com.google.guava:guava</bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.databridge.agent.thrift</bundleDef>
 				 <importBundleDef>org.apache.hadoop.wso2:hadoop-core</importBundleDef>
                             </bundles>

--- a/pom.xml
+++ b/pom.xml
@@ -1108,7 +1108,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>13.0.1</version>
+                <version>${google.guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ws.commons.schema.wso2</groupId>
@@ -1379,11 +1379,6 @@
                 <groupId>org.hectorclient.wso2</groupId>
                 <artifactId>hector-core</artifactId>
                 <version>${hector.wso2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava.wso2</groupId>
-                <artifactId>guava</artifactId>
-                <version>${google.guava.wso2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -1896,8 +1891,7 @@
         <orbit.version.wsdl4j>1.6.2.wso2v4</orbit.version.wsdl4j>
         <quartz2.wso2.version>2.1.1.wso2v1</quartz2.wso2.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.0.wso2v1</orbit.version.geronimo-jms_1.1_spec>
-        <google.guava.wso2.version>12.0.0.wso2v1</google.guava.wso2.version>
-        <google.guava.version>13.0.1</google.guava.version>
+        <google.guava.version>19.0</google.guava.version>
         <hadoop.version>0.20.203.1-wso2v2</hadoop.version>
         <jdbc-pool.version>7.0.34.wso2v2</jdbc-pool.version>
         <hadoop.orbit.version>0.20.203.1.wso2v2</hadoop.orbit.version>


### PR DESCRIPTION
upgrading guava from 13 to 19 and removing the 12.0.1 wso2 version from the dependencies
