### PR TITLE
CCOMMONS-13 - Jasper report version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1831,7 +1831,7 @@
 
         <!-- Jasper Reports Version -->
         <version.jasper>2.2.2.v201205150955</version.jasper>
-        <jasperreports.wso2.version>6.1.1.wso2v1</jasperreports.wso2.version>
+        <jasperreports.wso2.version>6.1.1.wso2v2</jasperreports.wso2.version>
 
         <!-- Equinox dependency versions -->
         <version.equinox.osgi>3.8.1.v20120830-144521</version.equinox.osgi>


### PR DESCRIPTION
This fix is required to to build the product g-reg when updated to kernel 4.4.6 version