### PR TITLE
Fix issue when task resume.

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/clustered/ClusteredTaskManager.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/clustered/ClusteredTaskManager.java
@@ -168,7 +168,7 @@ public class ClusteredTaskManager extends AbstractQuartzTaskManager {
     public void resumeTask(String taskName) throws TaskException {
         String memberId = this.getMemberIdFromTaskName(taskName, false);
         this.resumeTask(memberId, taskName);
-        TaskUtils.setTaskPaused(this.getTaskRepository(), taskName, true);
+        TaskUtils.setTaskPaused(this.getTaskRepository(), taskName, false);
     }
 
     @Override


### PR DESCRIPTION
Fix setting the correct state when a task is resumed in a clustered environment.
Resolves https://github.com/wso2/carbon-commons/issues/274

Unit / integration test is not possible to verify this fix, hence the issue can be only observed in a clustered environment