### PR TITLE
Fix view large messages through the System logs

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/data/LogEvent.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/data/LogEvent.java
@@ -16,6 +16,9 @@
 package org.wso2.carbon.logging.service.data;
 
 public class LogEvent {
+
+    private static final int MAX_LOG_MESSAGE_LENGTH = 250;
+
     private String key;
     private String tenantId;
     private String serverName;
@@ -112,6 +115,28 @@ public class LogEvent {
 
     public String getMessage() {
         return message;
+    }
+
+    /**
+     * Returns the message string for the log event.
+     * If the message string length is greater that {@value MAX_LOG_MESSAGE_LENGTH} then the message string
+     * will be truncated to the length of {@value MAX_LOG_MESSAGE_LENGTH} and returned.
+     * The truncation of the message is handled in server side to avoid client downloading the full log message.
+     *
+     * @return message string
+     */
+    public String getTruncatedMessage() {
+        return message.length() > MAX_LOG_MESSAGE_LENGTH ?
+               message.substring(0, MAX_LOG_MESSAGE_LENGTH) + "..." : message;
+    }
+
+    /**
+     * Returns whether the message length is larger than {@value MAX_LOG_MESSAGE_LENGTH}.
+     *
+     * @return true if the message length is larger than {@value MAX_LOG_MESSAGE_LENGTH}, false otherwise
+     */
+    public boolean getIsMessageTruncatable() {
+        return message.length() > MAX_LOG_MESSAGE_LENGTH;
     }
 
     public void setMessage(String message) {

--- a/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/org/wso2/carbon/logging/view/ui/i18n/Resources.properties
+++ b/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/org/wso2/carbon/logging/view/ui/i18n/Resources.properties
@@ -42,4 +42,4 @@ view.logs.within.the.past.thirty.mins=Logs taken within past thirty minutes.
 view.logs.between=Logs taken between.
 log.level=Level
 current.time=Current Time Zone:
-
+indicate.large.log.message=(message, truncated due its large size)

--- a/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/web/log-view/application_log_viewer.jsp
+++ b/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/web/log-view/application_log_viewer.jsp
@@ -306,7 +306,7 @@
 										src="<%=logViewerClient.getImageName(logMessage.getPriority().trim())%>">
 									</td>
 									<td><nobr><%=logMessage.getLogTime()%></nobr></td>
-									<td><%=CharacterEncoder.getSafeText(logMessage.getMessage())%></td>
+									<td><%=CharacterEncoder.getSafeText(logMessage.getTruncatedMessage())%></td>
 										<%
 											String imgId = "traceSymbolMax" + index;
 										%>
@@ -332,8 +332,16 @@
 										}
 									%>
 
-                                    <td colspan="4" width="100%">TID[<%=logMessage.getTenantId()%>] AppID[<%=logMessage.getAppName()%>] [<%=logMessage.getServerName()%>] [<%=logMessage.getLogTime()%>] <%=logMessage.getPriority().trim()%> {<%=logMessage.getLogger()%>} - <%=CharacterEncoder.getSafeText(logMessage.getMessage())%>
-                                        <%=logMessage.getStacktrace()%><br/>
+                                    <td colspan="4" width="100%">TID[<%=logMessage.getTenantId()%>] AppID[<%=logMessage.getAppName()%>] [<%=logMessage.getServerName()%>] [<%=logMessage.getLogTime()%>] <%=logMessage.getPriority().trim()%> {<%=logMessage.getLogger()%>} - <%=CharacterEncoder.getSafeText(logMessage.getTruncatedMessage())%>
+                                        <%=logMessage.getStacktrace()%>
+                                        <%
+                                            if (logMessage.getIsMessageTruncatable()) {
+                                        %>
+                                        <fmt:message key="indicate.large.log.message"/>
+                                        <%
+                                            }
+                                        %>
+                                        <br/>
                                     </td>
 									</tr>
 							<%

--- a/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/web/log-view/index.jsp
+++ b/components/logging/org.wso2.carbon.logging.view.ui/src/main/resources/web/log-view/index.jsp
@@ -468,7 +468,7 @@
 										src="<%=logViewerClient.getImageName(logMessage.getPriority().trim())%>">
 									</td>
 									<td><nobr><%=logMessage.getLogTime()%></nobr></td>
-									<td><%=CharacterEncoder.getSafeText(logMessage.getMessage())%></td>
+									<td><%=CharacterEncoder.getSafeText(logMessage.getTruncatedMessage())%></td>
 										<%
 											String imgId = "traceSymbolMax" + index;
 										%>
@@ -494,8 +494,16 @@
 										}
 									%>
 								
-									<td colspan="4" width="100%">TID[<%=logMessage.getTenantId()%>] [<%=logMessage.getServerName()%>] [<%=logMessage.getLogTime()%>] <%=logMessage.getPriority().trim()%> {<%=logMessage.getLogger()%>} - <%=CharacterEncoder.getSafeText(logMessage.getMessage())%> 
-										<%=logMessage.getStacktrace()%><br/>
+									<td colspan="4" width="100%">TID[<%=logMessage.getTenantId()%>] [<%=logMessage.getServerName()%>] [<%=logMessage.getLogTime()%>] <%=logMessage.getPriority().trim()%> {<%=logMessage.getLogger()%>} - <%=CharacterEncoder.getSafeText(logMessage.getTruncatedMessage())%>
+										<%=logMessage.getStacktrace()%>
+                                        <%
+                                            if (logMessage.getIsMessageTruncatable()) {
+                                        %>
+                                        <fmt:message key="indicate.large.log.message"/>
+                                        <%
+                                            }
+                                        %>
+                                        <br/>
 									</td>
 									</tr>
 							<%

--- a/service-stubs/logging/org.wso2.carbon.logging.view.stub/src/main/resources/LogViewer.wsdl
+++ b/service-stubs/logging/org.wso2.carbon.logging.view.stub/src/main/resources/LogViewer.wsdl
@@ -335,6 +335,7 @@
                <xs:element minOccurs="0" name="appName" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="instance" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="ip" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="isMessageTruncatable" type="xs:boolean"/>
                <xs:element minOccurs="0" name="key" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="logTime" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="logger" nillable="true" type="xs:string"/>
@@ -343,6 +344,7 @@
                <xs:element minOccurs="0" name="serverName" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="stacktrace" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="tenantId" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="truncatedMessage" nillable="true" type="xs:string"/>
             </xs:sequence>
          </xs:complexType>
       </xs:schema>


### PR DESCRIPTION
Fixed viewing large messages through the System logs of the Management Console without breaking the UI
Resolves https://wso2.org/jira/browse/CARBON-16109