### PR TITLE
Add granular permissions for capps and connectors

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.mgt.ui/src/main/resources/META-INF/component.xml
+++ b/components/application-mgt/org.wso2.carbon.application.mgt.ui/src/main/resources/META-INF/component.xml
@@ -16,6 +16,22 @@
  ~ under the License.
  -->
 <component xmlns="http://products.wso2.org/carbon">
+
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>Carbon Applications</DisplayName>
+            <ResourceId>/permission/admin/manage/capps</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>list</DisplayName>
+            <ResourceId>/permission/admin/manage/capps/list</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>add</DisplayName>
+            <ResourceId>/permission/admin/manage/capps/add</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
+
 	<menus>
 	    <menu>
             <id>apps_menu</id>
@@ -38,7 +54,7 @@
 			<order>5</order>
 			<style-class>manage</style-class>
             <icon>../carbonapps/images/list.gif</icon>
-            <require-permission>/permission/admin/manage</require-permission>
+            <require-permission>/permission/admin/manage/capps/list</require-permission>
         </menu>
 		 <menu>
             <id>apps_add_menu</id>
@@ -50,7 +66,7 @@
             <order>10</order>
             <style-class>manage</style-class>
             <icon>../carbonapps/images/add.gif</icon>
-            <require-permission>/permission/admin/manage/add/application</require-permission>
+            <require-permission>/permission/admin/manage/capps/add</require-permission>
         </menu>
 	</menus>
 

--- a/components/application-mgt/org.wso2.carbon.application.mgt/src/main/resources/META-INF/services.xml
+++ b/components/application-mgt/org.wso2.carbon.application.mgt/src/main/resources/META-INF/services.xml
@@ -27,7 +27,7 @@
         <parameter name="enableMTOM" locked="false">true</parameter>
     </service>
 
-    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage</parameter>
+    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/capps</parameter>
     <parameter name="adminService" locked="true">true</parameter>
     <parameter name="hiddenService" locked="true">true</parameter>
 </serviceGroup>

--- a/components/application-mgt/org.wso2.carbon.application.upload/src/main/resources/META-INF/services.xml
+++ b/components/application-mgt/org.wso2.carbon.application.upload/src/main/resources/META-INF/services.xml
@@ -32,5 +32,5 @@
 
     <parameter name="adminService" locked="true">true</parameter>
     <parameter name="hiddenService" locked="true">true</parameter>
-    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/application</parameter>
+    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/capps/add</parameter>
 </serviceGroup>


### PR DESCRIPTION
Currently, the list/add actions for connectors and carbon apps are assigned to "permission/admin/manage" root level permission. In a scenario where a user needs to give only specific permissions (e.g. identity/user/add) under "permission/admin/manage", the current approach will not work. Therefore adding more granular permissions.

Git Issue       : https://github.com/wso2/product-ei/issues/932