### PR TITLE
[Scheduled Task] Change data-type of task interval to long

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskInfo.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskInfo.java
@@ -192,7 +192,7 @@ public class TaskInfo implements Serializable {
 
         private Date endTime;
 
-        private int intervalMillis;
+        private long intervalMillis;
 
         private int repeatCount;
 
@@ -205,7 +205,7 @@ public class TaskInfo implements Serializable {
         public TriggerInfo() {
         }
 
-        public TriggerInfo(Date startTime, Date endTime, int intervalMillis, int repeatCount) {
+        public TriggerInfo(Date startTime, Date endTime, long intervalMillis, int repeatCount) {
             this.startTime = startTime;
             this.endTime = endTime;
             this.intervalMillis = intervalMillis;
@@ -232,7 +232,7 @@ public class TaskInfo implements Serializable {
             this.endTime = endTime;
         }
 
-        public void setIntervalMillis(int intervalMillis) {
+        public void setIntervalMillis(long intervalMillis) {
             this.intervalMillis = intervalMillis;
         }
 
@@ -270,7 +270,7 @@ public class TaskInfo implements Serializable {
         }
 
         @XmlElement(name = "intervalMillis")
-        public int getIntervalMillis() {
+        public long getIntervalMillis() {
             return intervalMillis;
         }
 

--- a/service-stubs/remote-tasks/org.wso2.carbon.remote-tasks.stub/src/main/resources/RemoteTaskAdmin.wsdl
+++ b/service-stubs/remote-tasks/org.wso2.carbon.remote-tasks.stub/src/main/resources/RemoteTaskAdmin.wsdl
@@ -11,7 +11,7 @@
                     <xs:element minOccurs="0" name="endTime" nillable="true" type="xs:dateTime"/>
                     <xs:element minOccurs="0" name="startTime" nillable="true" type="xs:dateTime"/>
                     <xs:element minOccurs="0" name="taskCount" type="xs:int"/>
-                    <xs:element minOccurs="0" name="taskInterval" type="xs:int"/>
+                    <xs:element minOccurs="0" name="taskInterval" type="xs:long"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="DeployedTaskInformation">


### PR DESCRIPTION
## Purpose
> Resolves https://wso2.org/jira/browse/ESBJAVA-5234

## Goals
> This is to fix the following exception thrown when a scheduled task is created with large task interval values(> Integer.MAX_VALUE). java.lang.IllegalArgumentException: Repeat interval must be >= 0. 

## Approach
> The above exception is thrown due to casting a long into int, since the task interval is defined as int. So to fix this, the task interval data type is changed to long.

## User stories
> N/A

## Release note
> Fix for the exception thrown when a scheduled task is created with large task interval values(> Integer.MAX_VALUE)

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A. This fix includes a change for an internal representation of a parameter.

## Marketing
> N/A

## Automation tests
 - Integration tests
   > org.wso2.carbon.esb.scheduledtask.test.TaskWithLargeIntervalValueTestCase (https://github.com/wso2/product-ei/pull/1112)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A. This PR contains a bug fix.

## Related PRs
> https://github.com/wso2/carbon-mediation/pull/888, https://github.com/wso2/product-ei/pull/1112

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8, Ubuntu 16.04
 
## Learning
> N/A