### PR TITLE
Add Local task deletion listener to be notified

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskManager.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskManager.java
@@ -16,6 +16,7 @@
 package org.wso2.carbon.ntask.core;
 
 import org.wso2.carbon.ntask.common.TaskException;
+import org.wso2.carbon.ntask.core.impl.LocalTaskActionListener;
 
 import java.util.List;
 
@@ -111,5 +112,13 @@ public interface TaskManager {
     public enum TaskState {
         NORMAL, PAUSED, ERROR, FINISHED, NONE, BLOCKED, UNKNOWN
     }
+
+    /**
+     * Registers a listener to be notified when an action is performed on a task.
+     *
+     * @param listener the listener to be notified
+     * @param taskName the name of the task for which the listener should be registered
+     */
+    void registerLocalTaskActionListener(LocalTaskActionListener listener, String taskName);
 
 }

--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/LocalTaskActionListener.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/LocalTaskActionListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.ntask.core.impl;
+
+/**
+ * Listener to be notified when a task is deleted at {@link org.wso2.carbon.ntask.core.TaskManager}. Any class that
+ * needs to be notified when a task that was scheduled to be run locally is deleted, should implement this.
+ */
+public interface LocalTaskActionListener {
+
+    /**
+     * Method to notify when a local task is deleted.
+     * @param taskName
+     */
+    void notifyLocalTaskDeletion(String taskName);
+}

--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/remote/RemoteTaskManager.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/remote/RemoteTaskManager.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.ntask.core.Task;
 import org.wso2.carbon.ntask.core.TaskInfo;
 import org.wso2.carbon.ntask.core.TaskManager;
 import org.wso2.carbon.ntask.core.TaskRepository;
+import org.wso2.carbon.ntask.core.impl.LocalTaskActionListener;
 import org.wso2.carbon.ntask.core.impl.RegistryBasedTaskRepository;
 import org.wso2.carbon.ntask.core.internal.TasksDSComponent;
 import org.wso2.carbon.registry.core.Registry;
@@ -474,6 +475,11 @@ public class RemoteTaskManager implements TaskManager {
         public void execute(ConfigurationContext ctx) throws ClusteringFault {
         }
 
+    }
+
+    @Override
+    public void registerLocalTaskActionListener(LocalTaskActionListener listener, String taskName) {
+        //Do nothing since this is the remote task manager and there are no local tasks associated to it.
     }
 
 }


### PR DESCRIPTION
## Purpose
Resolves: https://github.com/wso2/product-ei/issues/1135

## Goals
Enables writting a listener to be notified when a an action is performed on a task.

## Approach
Adds a listener to 'AbstractQuartzTaskManager' to be notified when an action is performed on a task. Also notifies listeners when a local task is deleted.

## Release note
This fix enables writting a listener to be notified when a an action is performed on a task by the 'AbstractQuartzTaskManager'.

## Documentation
N/A. This is an internal implementation which is not useful to an end user.

## Certification
N/A. The implementation is done as a resolution to an issue which is an edge case in CAR deployment with a JMS inbound endpoint.

## Automation tests
N/A. The issue only occurs in a clustered environment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-mediation/pull/895

## Migrations (if applicable)
N/A

## Test environment
java version "1.8.0_131"