### PR TITLE
Throw an exception if the rule does not match

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RuleBasedLocationResolver.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RuleBasedLocationResolver.java
@@ -71,8 +71,8 @@ public class RuleBasedLocationResolver implements TaskLocationResolver {
 	public int getLocation(TaskServiceContext ctx, TaskInfo taskInfo)
 			throws TaskException {
 		List<Integer> locations;
-		/* if matched by no one, lets just assign it to the first server */
-		int result = 0;
+		/* if matched by no one, then throws a TaskException to prevent scheduling. */
+		int result = -1;
 		for (Rule rule : this.rules) {
 			try {
 			    locations = rule.evaluate(ctx, taskInfo);
@@ -92,6 +92,10 @@ public class RuleBasedLocationResolver implements TaskLocationResolver {
 		if (log.isDebugEnabled()) {
 			log.debug("Task location resolved to: " + result + 
 					" for task: [" + ctx.getTaskType() + "][" + taskInfo.getName() + "]");
+		}
+		if (result == -1) {
+			throw new TaskException("Task location unavailable for RuleBasedLocationResolver: "
+					+ ctx.getTaskType() + "#" + taskInfo.getName(), Code.TASK_NODE_NOT_AVAILABLE);
 		}
 		return result;
 	}


### PR DESCRIPTION
## Purpose
Prevent task getting scheduled in not assign nodes.
Resolves https://wso2.org/jira/browse/ESBJAVA-5286

## Goals
Get a pinned server kind behavior and prevent task getting scheduled if allowed node available in the cluster.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this 