### PR TITLE
Fix product-ei#1830

### DIFF
--- a/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/subscription/registry/RegistrySubscriptionManager.java
+++ b/components/event/org.wso2.carbon.event.core/src/main/java/org/wso2/carbon/event/core/internal/subscription/registry/RegistrySubscriptionManager.java
@@ -17,6 +17,8 @@
 package org.wso2.carbon.event.core.internal.subscription.registry;
 
 import org.apache.axis2.databinding.utils.ConverterUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.event.core.exception.EventBrokerConfigurationException;
 import org.wso2.carbon.event.core.exception.EventBrokerException;
 import org.wso2.carbon.event.core.internal.util.EventBrokerHolder;
@@ -53,6 +55,7 @@ import java.util.Properties;
  */
 @Deprecated
 public class RegistrySubscriptionManager implements SubscriptionManager {
+    private static final Log log = LogFactory.getLog(RegistrySubscriptionManager.class);
 
     /**
      * Star wildcard - can substitute for exactly one word.
@@ -289,7 +292,7 @@ public class RegistrySubscriptionManager implements SubscriptionManager {
             }
 
         } catch (RegistryException e) {
-            throw new EventBrokerException("Cannot access the registry ", e);
+            log.error("Cannot access the registry while listing all the available subscriptions. " + e);
         }
         return subscriptions;
     }


### PR DESCRIPTION
Fix the issue of server not starting when the registry resource is not available. As the fix we have avoided throwing the EventBrokerException when the subscription registry resource is not available. This will enable initializing CarbonEventBroker for available subscriptions.

## Purpose
Fixed https://github.com/wso2/product-ei/issues/1830
