### PR TITLE
Fix capp listing permission issue wso2/product-ei#2146

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.mgt/src/main/resources/META-INF/services.xml
+++ b/components/application-mgt/org.wso2.carbon.application.mgt/src/main/resources/META-INF/services.xml
@@ -27,7 +27,7 @@
         <parameter name="enableMTOM" locked="false">true</parameter>
     </service>
 
-    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/capps</parameter>
+    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/capps/list</parameter>
     <parameter name="adminService" locked="true">true</parameter>
     <parameter name="hiddenService" locked="true">true</parameter>
 </serviceGroup>


### PR DESCRIPTION
## Purpose
> Fixes wso2/product-ei#2146

## Goals
> Resolves wso2/product-ei#2146

## Approach
> Added relevant permission string to the services.xml in order to view the uploaded capps.