### PR TITLE
Add distributed synchronization for register task in clustered environment

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/clustered/ClusteredTaskManager.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/clustered/ClusteredTaskManager.java
@@ -176,12 +176,19 @@ public class ClusteredTaskManager extends AbstractQuartzTaskManager {
         /* if the task registration already exists, we have to make sure we save the current location
          * of the task, since this is a task registration update, we will want to schedule the task
          * in the same server as earlier */
-        String locationId = this.getTaskRepository().getTaskMetadataProp(
-                taskInfo.getName(), TASK_MEMBER_LOCATION_META_PROP_ID);
-        this.registerLocalTask(taskInfo);
-        if (locationId != null) {
-            this.getTaskRepository().setTaskMetadataProp(taskInfo.getName(),
-                    TASK_MEMBER_LOCATION_META_PROP_ID, locationId);
+        String taskLockId = this.getTaskType() + "_" + this.getTenantId() + "_" + taskInfo.getName();
+        Lock lock = this.getClusterComm().getHazelcast().getLock(taskLockId);
+        try {
+            lock.lock();
+            String locationId = this.getTaskRepository().getTaskMetadataProp(
+                    taskInfo.getName(), TASK_MEMBER_LOCATION_META_PROP_ID);
+            this.registerLocalTask(taskInfo);
+            if (locationId != null) {
+                this.getTaskRepository().setTaskMetadataProp(taskInfo.getName(),
+                        TASK_MEMBER_LOCATION_META_PROP_ID, locationId);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION

## Purpose
>Resolves [#2172](https://github.com/wso2/product-ei/issues/2172) 

## Goals
> The scheduled task runs on both worker nodes when performing rapid continuous rolling restarts of worker nodes due to not having distributed synchronization on registerTask method.

## Approach
> Add distributed lock to the method which is used to register task.
