### PR TITLE
Fix wso2/product-ei#2939 and wso2/product-ei#2938

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.mgt/src/main/java/org/wso2/carbon/application/mgt/ApplicationAdmin.java
+++ b/components/application-mgt/org.wso2.carbon.application.mgt/src/main/java/org/wso2/carbon/application/mgt/ApplicationAdmin.java
@@ -291,9 +291,7 @@ public class ApplicationAdmin extends AbstractAdmin {
             String type = artifact.getType();
             String instanceName = artifact.getRuntimeObjectName();
 
-            if (DefaultAppDeployer.AAR_TYPE.equals(type) ||
-                    DefaultAppDeployer.DS_TYPE.equals(type)) {
-
+            if (DefaultAppDeployer.AAR_TYPE.equals(type)) {
                 AxisServiceGroup sg;
                 if (instanceName == null) {
                     sg = findServiceGroupForArtifact(artifact);
@@ -477,8 +475,6 @@ public class ApplicationAdmin extends AbstractAdmin {
 
         if (serviceType.equals("axis2")) {
             artifactType = DefaultAppDeployer.AAR_TYPE;
-        } else if (serviceType.equals("data_service")) {
-            artifactType = DefaultAppDeployer.DS_TYPE;
         }
         return artifactType;
     }

--- a/components/ndatasource/org.wso2.carbon.ndatasource.capp.deployer/pom.xml
+++ b/components/ndatasource/org.wso2.carbon.ndatasource.capp.deployer/pom.xml
@@ -62,7 +62,8 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             !org.wso2.carbon.datasource.capp.deployer.internal,
-                            org.wso2.carbon.datasource.capp.deployer;version="${project.version}"
+                            org.wso2.carbon.datasource.capp.deployer;version="${project.version}",
+                            org.wso2.carbon.ndatasource.capp.deployer;version="${project.version}"
                         </Export-Package>
                         <Import-Package>
                             !org.wso2.carbon.datasource.capp.deployer,

--- a/components/ndatasource/org.wso2.carbon.ndatasource.capp.deployer/src/main/java/org/wso2/carbon/ndatasource/capp/deployer/DataSourceCappDeployer.java
+++ b/components/ndatasource/org.wso2.carbon.ndatasource.capp.deployer/src/main/java/org/wso2/carbon/ndatasource/capp/deployer/DataSourceCappDeployer.java
@@ -178,9 +178,7 @@ public class DataSourceCappDeployer implements AppDeploymentHandler {
             InputStream in = new FileInputStream(file);
 
             Document doc = DataSourceUtils.convertToDocument(in);
-            /* only super tenant will lookup secure vault information for system data sources,
-             * others are not allowed to */
-            DataSourceUtils.secureResolveDocument(doc, false);
+            DataSourceUtils.secureResolveDocument(doc, true);
 
             // create JAXB context and initializing Marshaller
             JAXBContext jaxbContext = JAXBContext.newInstance(DataSourceMetaInfo.class);

--- a/features/ndatasource/org.wso2.carbon.ndatasource.feature/pom.xml
+++ b/features/ndatasource/org.wso2.carbon.ndatasource.feature/pom.xml
@@ -18,9 +18,14 @@
 			<artifactId>org.wso2.carbon.ndatasource.ui.feature</artifactId>
 			<type>zip</type>
 		</dependency>
-                <dependency>
+		<dependency>
 			<groupId>org.wso2.carbon.commons</groupId>
 			<artifactId>org.wso2.carbon.ndatasource.datasources.feature</artifactId>
+			<type>zip</type>
+		</dependency>
+		<dependency>
+			<groupId>org.wso2.carbon.commons</groupId>
+			<artifactId>org.wso2.carbon.ndatasource.capp.deployer.server.feature</artifactId>
 			<type>zip</type>
 		</dependency>
 	</dependencies>
@@ -46,7 +51,8 @@
 							</importFeatures>
 							<includedFeatures>
 								<includedFeatureDef>org.wso2.carbon.commons:org.wso2.carbon.ndatasource.ui.feature:${carbon.commons.version}</includedFeatureDef>
-                                                                <includedFeatureDef>org.wso2.carbon.commons:org.wso2.carbon.ndatasource.datasources.feature:${carbon.commons.version}</includedFeatureDef>
+								<includedFeatureDef>org.wso2.carbon.commons:org.wso2.carbon.ndatasource.datasources.feature:${carbon.commons.version}</includedFeatureDef>
+								<includedFeatureDef>org.wso2.carbon.commons:org.wso2.carbon.ndatasource.capp.deployer.server.feature:${carbon.commons.version}</includedFeatureDef>
 							</includedFeatures>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1529,6 +1529,12 @@
                 <artifactId>encoder</artifactId>
                 <version>${encoder.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.commons</groupId>
+                <artifactId>org.wso2.carbon.ndatasource.capp.deployer.server.feature</artifactId>
+                <version>${carbon.commons.version}</version>
+                <type>zip</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose

> Export org.wso2.carbon.ndatasource.capp.deployer package to use in the org.wso2.carbon.dataservices.capp.deployer.
Remove code segments related to DafaultAppDeploye data services in ApplicationAdmin.java.
Getting an error while deploying a data source which has a secret alias as the password via a capp, changed secret alias evaluation to true.
Include org.wso2.carbon.ndatasource.capp.deployer.server.feature to org.wso2.carbon.ndatasource.ui.feature

## Related PRs

- https://github.com/wso2/carbon-kernel/pull/1900
- https://github.com/wso2/carbon-data/pull/225

## Test environment

- JDK version: 1.8.0_181
- Operating system: Mac OS High Sierra