### PR TITLE
Enable output encoding for datasource provider field

### DIFF
--- a/components/ndatasource/org.wso2.carbon.ndatasource.ui/src/main/resources/web/ndatasource/newdatasource.jsp
+++ b/components/ndatasource/org.wso2.carbon.ndatasource.ui/src/main/resources/web/ndatasource/newdatasource.jsp
@@ -572,7 +572,7 @@ function displayPasswordField() {
                         <%=NDataSourceClientConstants.RDBMS_EXTERNAL_DATASOURCE_PROVIDER%></option>
                    	<% } %>
          </select>
-         <input type="hidden" id="dsProviderType" name="dsProviderType" value="<%=dsProvider %>" />
+         <input type="hidden" id="dsProviderType" name="dsProviderType" value="<%=Encode.forJavaScript(dsProvider)%>"/>
          <input type="hidden" id="dsproviderProperties" name="dsproviderProperties" class="longInput"/>
          <input type="hidden" id="dsproviderPropertiesHidden" name="dsproviderPropertiesHidden" class="longInput" value="<%=dsproviderPropertiesEditMode %>"/>
     </td>


### PR DESCRIPTION
## Purpose

Purpose of this PR is to enable output encoding for datasource provider field due to security vulnerability.

## Approach

Encode datasource provider value
Add relevant dependencies

## Test environment

This is tested locally in following environment.
JDK - 1.8
OS - macOS High Sierra