### PR TITLE
Fix Nullpointer exception when shutting down IS server.

### DIFF
--- a/components/system-statistics/org.wso2.carbon.statistics/src/main/java/org/wso2/carbon/statistics/internal/StatisticsServiceComponent.java
+++ b/components/system-statistics/org.wso2.carbon.statistics/src/main/java/org/wso2/carbon/statistics/internal/StatisticsServiceComponent.java
@@ -119,15 +119,18 @@ public class StatisticsServiceComponent {
     protected void unsetConfigurationContextService(ConfigurationContextService contextService) {
 
         AxisConfiguration axisConf = configContext.getAxisConfiguration();
-        AxisModule statModule = axisConf.getModule(StatisticsConstants.STATISTISTICS_MODULE_NAME);
-        if (statModule != null) {
-            try {
-                axisConf.disengageModule(statModule);
-            } catch (AxisFault axisFault) {
-                log.error("Failed disengage module: " + StatisticsConstants.STATISTISTICS_MODULE_NAME);
+        if (axisConf != null) {
+            AxisModule statModule = axisConf.getModule(StatisticsConstants.STATISTISTICS_MODULE_NAME);
+            if (statModule != null) {
+                try {
+                    axisConf.disengageModule(statModule);
+                } catch (AxisFault axisFault) {
+                    log.error("Failed disengage module: " + StatisticsConstants.STATISTISTICS_MODULE_NAME);
+                }
             }
+            this.configContext = null;
         }
-        this.configContext = null;
+
     }
 
     @Reference(


### PR DESCRIPTION
## Purpose
> Fix Nullpointer exception when shutting down IS server.

```
 [SCR] Exception occurred while unbinding reference Reference[name = config.context.service, interface = org.wso2.carbon.utils.ConfigurationContextService, policy = dynamic, cardinality = 1..1, target = null, bind = setConfigurationContextService, unbind = unsetConfigurationContextService]
	Details:
	Problematic reference = Reference[name = config.context.service, interface = org.wso2.carbon.utils.ConfigurationContextService, policy = dynamic, cardinality = 1..1, target = null, bind = setConfigurationContextService, unbind = unsetConfigurationContextService]
	of service component = statistics.service.component
	component implementation class = org.wso2.carbon.statistics.internal.StatisticsServiceComponent
	located in bundle with symbolic name = org.wso2.carbon.statistics
	bundle location = reference:file:../plugins/org.wso2.carbon.statistics_4.7.2.jar java.lang.reflect.InvocationTargetException
```