### PR TITLE
Make carbon-commons buildable in Java 11

### DIFF
--- a/components/ndatasource/org.wso2.carbon.ndatasource.ui/pom.xml
+++ b/components/ndatasource/org.wso2.carbon.ndatasource.ui/pom.xml
@@ -76,5 +76,11 @@
             <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/components/ntask/org.wso2.carbon.ntask.common/pom.xml
+++ b/components/ntask/org.wso2.carbon.ntask.common/pom.xml
@@ -57,5 +57,11 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/components/ntask/org.wso2.carbon.ntask.core/pom.xml
+++ b/components/ntask/org.wso2.carbon.ntask.core/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/tenant-mgt-common/org.wso2.carbon.tenant.common/pom.xml
+++ b/components/tenant-mgt-common/org.wso2.carbon.tenant.common/pom.xml
@@ -92,5 +92,11 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1474,6 +1474,11 @@
                 <artifactId>org.eclipse.equinox.event</artifactId>
                 <version>${version.eclipse.equinox.event}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.jaxb.api}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1930,6 +1935,7 @@
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>
         <version.eclipse.equinox.event>1.5.100</version.eclipse.equinox.event>
+        <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Purpose
Make carbon-commons buildable in Java 11

## Goals
Make carbon-commons buildable in Java 11

## Approach
Make carbon-commons buildable in Java 11

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A