### PR TITLE
Fix exception const

### DIFF
--- a/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LoggingUpdaterConstants.java
+++ b/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LoggingUpdaterConstants.java
@@ -26,5 +26,5 @@ public interface LoggingUpdaterConstants {
 
     String PAX_LOGGING_CONFIGURATION_PID = "org.ops4j.pax.logging";
     String PAX_LOGGING_CONFIGURATION_TOPIC = "org/ops4j/pax/logging/Configuration";
-    String EXCEPTIONS_PROPERTY = "exceptions";
+    String EXCEPTIONS_PROPERTY = "exception";
 }


### PR DESCRIPTION
Updating const name as per https://github.com/ops4j/org.ops4j.pax.logging/blob/master/pax-logging-api/src/main/java/org/ops4j/pax/logging/spi/support/EventAdminConfigurationNotifier.java#L61

```java
@Override
    public void configurationError(Throwable t) {
        EventAdmin ea = tracker.getService();
        if (ea != null) {
            LOG.warn("Sending Event Admin notification (configuration error) to " + PaxLoggingConstants.EVENT_ADMIN_CONFIGURATION_TOPIC);
            Map<String, Object> properties = new HashMap<>();
            properties.put("exception", t);
            ea.postEvent(new Event(PaxLoggingConstants.EVENT_ADMIN_CONFIGURATION_TOPIC, new EventProperties(properties)));
        } else {
            LOG.warn("Logging configuration problem. (Event Admin service unavailable - no notification sent).", t);
        }
    }
```