### PR TITLE
Retrieve the IP inside a static block

### DIFF
--- a/components/logging/org.wso2.carbon.logging.view/src/main/java/org/wso2/carbon/logging/view/appenders/LoggingAppender.java
+++ b/components/logging/org.wso2.carbon.logging.view/src/main/java/org/wso2/carbon/logging/view/appenders/LoggingAppender.java
@@ -38,6 +38,16 @@ import java.text.SimpleDateFormat;
 public class LoggingAppender implements PaxAppender {
 
     private CircularBuffer<LogEvent> circularBuffer;
+    private static String ip;
+
+    static {
+        try {
+            InetAddress localHost = InetAddress.getLocalHost();
+            ip = localHost.getHostAddress();
+        } catch (UnknownHostException var3) {
+            ip = "127.0.0.1";
+        }
+    }
 
     public LoggingAppender(CircularBuffer<LogEvent> logBuffer) {
 
@@ -54,7 +64,7 @@ public class LoggingAppender implements PaxAppender {
         logEvent.setLogTime(simpleDateFormat.format(paxLoggingEvent.getTimeStamp()));
         logEvent.setServerName(getServerName());
         logEvent.setTenantId(getTenantId());
-        logEvent.setIp(getIp());
+        logEvent.setIp(ip);
         logEvent.setAppName(getAppName());
         if (paxLoggingEvent.getThrowableStrRep() != null) {
             logEvent.setStacktrace(String.join("\n", paxLoggingEvent.getThrowableStrRep()));


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9284

## Goals
Retrieve the IP only once during an API invoke call from APIM 3.1.0 which will stop dropping the performance.

## Approach
- Introduced a static block inside **LoggingAppender** class which basically does the function that getIP function was doing.

## User stories
- Performance was increased by 25% for the issue https://github.com/wso2/product-apim/issues/9284