### PR TITLE
Revert "Rollback to log4j1"

### DIFF
--- a/components/logging/org.wso2.carbon.logging.updater/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.updater/pom.xml
@@ -45,7 +45,6 @@
                             !org.wso2.carbon.logging.updater.*,
                             org.wso2.carbon.utils.*;version="${carbon.kernel.imp.pkg.version}",
                             org.osgi.service.cm.*;version="[1.0.0,2.0.0)",
-                            org.osgi.service.event.*;version="[1.3,2)",
                             org.osgi.service.component.*;version="${osgi.service.imp.pkg.version}",
                             *;resolution:=optional
                         </Import-Package>


### PR DESCRIPTION
Reverts wso2/carbon-commons#448

Reason - To fix the test failures and will address the changes afters stabilising the integrations tests of the IS