### PR TITLE
Revert "Update pax logging"

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.upload/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.application.upload/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/caching-invalidator/org.wso2.carbon.caching.invalidator/pom.xml
+++ b/components/caching-invalidator/org.wso2.carbon.caching.invalidator/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.admin/pom.xml
+++ b/components/event/org.wso2.carbon.event.admin/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.client/pom.xml
+++ b/components/event/org.wso2.carbon.event.client/pom.xml
@@ -32,7 +32,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.common/pom.xml
+++ b/components/event/org.wso2.carbon.event.common/pom.xml
@@ -32,7 +32,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.core/pom.xml
+++ b/components/event/org.wso2.carbon.event.core/pom.xml
@@ -33,7 +33,7 @@
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.ui/pom.xml
+++ b/components/event/org.wso2.carbon.event.ui/pom.xml
@@ -31,7 +31,7 @@
     <url>http://wso2.org</url>
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.ws/pom.xml
+++ b/components/event/org.wso2.carbon.event.ws/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/pom.xml
+++ b/components/event/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
 

--- a/components/ganalytics/org.wso2.carbon.ganalytics.publisher/pom.xml
+++ b/components/ganalytics/org.wso2.carbon.ganalytics.publisher/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/ganalytics/pom.xml
+++ b/components/ganalytics/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/hostobjects/org.wso2.carbon.hostobjects.carbonutil/pom.xml
+++ b/components/hostobjects/org.wso2.carbon.hostobjects.carbonutil/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>js</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/hostobjects/org.wso2.carbon.hostobjects.sso/pom.xml
+++ b/components/hostobjects/org.wso2.carbon.hostobjects.sso/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>js</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <version>${pax.logging.api.version}</version>
         </dependency>

--- a/components/logging/org.wso2.carbon.logging.updater/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.updater/pom.xml
@@ -44,7 +44,7 @@
                         <Import-Package>
                             !org.wso2.carbon.logging.updater.*,
                             org.wso2.carbon.utils.*;version="${carbon.kernel.imp.pkg.version}",
-                            org.osgi.service.cm.*;version="[1.0.0,2.0.0)",
+                            org.osgi.service.cm.*,
                             org.osgi.service.component.*;version="${osgi.service.imp.pkg.version}",
                             *;resolution:=optional
                         </Import-Package>
@@ -60,7 +60,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/logging/org.wso2.carbon.logging.view/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.view/pom.xml
@@ -43,7 +43,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/logging/pom.xml
+++ b/components/logging/pom.xml
@@ -56,7 +56,7 @@
                 <artifactId>org.wso2.carbon.core</artifactId>
             </dependency>
             <dependency>
-                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+                <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
             </dependency>
             <dependency>

--- a/components/reporting/org.wso2.carbon.reporting.core/pom.xml
+++ b/components/reporting/org.wso2.carbon.reporting.core/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/reporting/org.wso2.carbon.reporting.util/pom.xml
+++ b/components/reporting/org.wso2.carbon.reporting.util/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.reporting.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/features/ntask/org.wso2.carbon.ntask.core.feature/pom.xml
+++ b/features/ntask/org.wso2.carbon.ntask.core.feature/pom.xml
@@ -97,6 +97,8 @@
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.remote-tasks.stub
                                 </bundleDef>
                                 <bundleDef>org.quartz-scheduler.wso2:quartz</bundleDef>
+                                <bundleDef>org.slf4j:slf4j-log4j12</bundleDef>
+                                <bundleDef>org.slf4j:slf4j-api</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -151,23 +145,11 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.registry.core</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.user.core</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
              <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -207,23 +189,11 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.tomcat</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -311,12 +281,6 @@
                 <groupId>org.apache.axis2.wso2</groupId>
                 <artifactId>axis2-client</artifactId>
                 <version>${orbit.version.axis2}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -404,7 +368,7 @@
             </dependency>
 
             <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
@@ -644,12 +608,6 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.securevault</artifactId>
                 <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -1342,12 +1300,6 @@
                 <groupId>org.wso2.securevault</groupId>
                 <artifactId>org.wso2.securevault</artifactId>
                 <version>${org.wso2.securevault.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -1358,12 +1310,6 @@
                 <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.ndatasource.stub</artifactId>
                 <version>${carbon.commons.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -1818,7 +1764,7 @@
 
     <properties>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.6.3</carbon.kernel.version>
+        <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
@@ -2022,7 +1968,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
         <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
-        <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
+        <pax.logging.api.version>1.11.0</pax.logging.api.version>
         <pax.logging.api.version.range>[2.1.0,2.2.0)</pax.logging.api.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>

--- a/service-stubs/cluster-mgt/pom.xml
+++ b/service-stubs/cluster-mgt/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/event/pom.xml
+++ b/service-stubs/event/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/logging/pom.xml
+++ b/service-stubs/logging/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
 

--- a/service-stubs/message-flows/pom.xml
+++ b/service-stubs/message-flows/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/ndatasource/org.wso2.carbon.ndatasource.stub/pom.xml
+++ b/service-stubs/ndatasource/org.wso2.carbon.ndatasource.stub/pom.xml
@@ -114,7 +114,7 @@
             </exclusions>
         </dependency>
 		<dependency>
-			<groupId>org.wso2.org.ops4j.pax.logging</groupId>
+			<groupId>org.ops4j.pax.logging</groupId>
 			<artifactId>pax-logging-api</artifactId>
 		</dependency>
 		<dependency>

--- a/service-stubs/org.wso2.carbon.adc.repositoryinformation.service.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.adc.repositoryinformation.service.stub/pom.xml
@@ -121,7 +121,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.application.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.application.mgt.stub/pom.xml
@@ -132,7 +132,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.deployment.synchronizer.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.deployment.synchronizer.stub/pom.xml
@@ -125,7 +125,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.discovery.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.discovery.stub/pom.xml
@@ -126,7 +126,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.identity.oauth.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.identity.oauth.stub/pom.xml
@@ -151,7 +151,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/remote-tasks/pom.xml
+++ b/service-stubs/remote-tasks/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/reporting/pom.xml
+++ b/service-stubs/reporting/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/soap-tracer/pom.xml
+++ b/service-stubs/soap-tracer/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/system-statistics/org.wso2.carbon.statistics.stub/pom.xml
+++ b/service-stubs/system-statistics/org.wso2.carbon.statistics.stub/pom.xml
@@ -131,7 +131,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/url-mapper/pom.xml
+++ b/service-stubs/url-mapper/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/wsdl-tools/org.wso2.carbon.wsdl2code.stub/pom.xml
+++ b/service-stubs/wsdl-tools/org.wso2.carbon.wsdl2code.stub/pom.xml
@@ -141,7 +141,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Reverts wso2/carbon-commons#447

Reason - To fix the test failures and will address the changes afters stabilising the integrations tests of the IS