### PR TITLE
Revert pax logging upgrade and temporarily increase version pax logging version range

### DIFF
--- a/components/logging/org.wso2.carbon.logging.view/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.view/pom.xml
@@ -22,7 +22,7 @@
                         <Private-Package>org.wso2.carbon.logging.view.internal</Private-Package>
                         <Import-Package>
                             !org.wso2.carbon.logging.view.*,
-                            org.wso2.org.ops4j.pax.logging.spi.*;version="${pax.logging.api.version.range}",
+                            org.ops4j.pax.logging.spi.*;version="${pax.logging.api.version.range}",
                             org.wso2.carbon.utils.logging.*;version="${carbon.kernel.imp.pkg.version}",
                             org.osgi.service.component.*;version="${osgi.service.imp.pkg.version}",
                             *;resolution:=optional

--- a/pom.xml
+++ b/pom.xml
@@ -1969,7 +1969,7 @@
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
         <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
         <pax.logging.api.version>1.11.0</pax.logging.api.version>
-        <pax.logging.api.version.range>[2.1.0,2.2.0)</pax.logging.api.version.range>
+        <pax.logging.api.version.range>[1.11.0,2.2.0)</pax.logging.api.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>


### PR DESCRIPTION
## Purpose
 - Temporarily increase the version range of the pax logging until the pax logging is upgraded in IS
 - The pax logging upgrade for "org.wso2.org.ops4j.pax.logging" (WSO2 managed) is rollbacked to use the previous 3rd party pax-logging dependency.
