### PR TITLE
Hazelcast removal

### DIFF
--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskServiceContext.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/TaskServiceContext.java
@@ -17,8 +17,6 @@ package org.wso2.carbon.ntask.core;
 
 import org.wso2.carbon.ntask.common.TaskException;
 
-import com.hazelcast.core.Member;
-
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -31,17 +29,8 @@ public class TaskServiceContext {
     private TaskRepository taskRepo;
 
     private List<String> memberIds;
-    
-    private Map<String, Member> memberMap;
 
     private static final String LOCAL_MEMBER_IDENTIFIER = "localMemberIdentifier";
-
-    public TaskServiceContext(TaskRepository taskRepo, List<String> memberIds, 
-            Map<String, Member> memberMap) {
-        this.taskRepo = taskRepo;
-        this.memberIds = memberIds;
-        this.memberMap = memberMap;
-    }
 
     public int getTenantId() {
         return this.taskRepo.getTenantId();
@@ -61,19 +50,11 @@ public class TaskServiceContext {
     
     public InetSocketAddress getServerAddress(int index) {
         String memberId = this.memberIds.get(index);
-        Member member = this.memberMap.get(memberId);
-        if (member == null) {
-            return null;
-        }
-        return member.getSocketAddress();
+        return null;
     }
 
     public String getServerIdentifier(int index) {
         String memberId = this.memberIds.get(index);
-        Member member = this.memberMap.get(memberId);
-        if (member == null) {
-            return null;
-        }
-        return member.getStringAttribute(LOCAL_MEMBER_IDENTIFIER);
+        return null;
     }
 }

--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RoundRobinTaskLocationResolver.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RoundRobinTaskLocationResolver.java
@@ -17,8 +17,6 @@ package org.wso2.carbon.ntask.core.impl;
 
 import java.util.Map;
 
-import com.hazelcast.core.HazelcastInstance;
-
 import org.wso2.carbon.ntask.common.TaskException;
 import org.wso2.carbon.ntask.core.TaskInfo;
 import org.wso2.carbon.ntask.core.TaskLocationResolver;
@@ -39,12 +37,8 @@ public class RoundRobinTaskLocationResolver implements TaskLocationResolver {
     
     @Override
     public int getLocation(TaskServiceContext ctx, TaskInfo taskInfo) throws TaskException {
-        HazelcastInstance hz = TasksDSComponent.getHazelcastInstance();
-        if (hz == null) {
-            /* this cannot happen, because the task location resolvers are used in clustered mode */
-            return 0;
-        }
-        return (int) Math.abs(hz.getAtomicLong(ROUND_ROBIN_TASK_RESOLVER_ID + ctx.getTaskType()).incrementAndGet());
+        // removed hazelcast
+        return 0;
     }
 
 }

--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RuleBasedLocationResolver.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/impl/RuleBasedLocationResolver.java
@@ -31,8 +31,6 @@ import org.wso2.carbon.ntask.core.TaskLocationResolver;
 import org.wso2.carbon.ntask.core.TaskServiceContext;
 import org.wso2.carbon.ntask.core.internal.TasksDSComponent;
 
-import com.hazelcast.core.HazelcastInstance;
-
 /**
  * This class represents a task location resolver, which assigns the locations
  * according to a filtering rules given as parameters. 
@@ -105,16 +103,8 @@ public class RuleBasedLocationResolver implements TaskLocationResolver {
 		if (log.isDebugEnabled()) {
 			log.debug("Performing RoundRobin for " + rule);
 		}
-		HazelcastInstance hz = TasksDSComponent.getHazelcastInstance();
-        if (hz == null) {
-            return 0;
-        }
-        int result = (int) Math.abs(hz.getAtomicLong(RULE_BASED_TASK_RESOLVER_ID + rule.hashCode()).incrementAndGet());
-        result = locations.get(result % locations.size());
-		if (log.isDebugEnabled()) {
-			log.debug("Selected Node for " + rule + " is " + result);
-		}
-		return result;
+		// removed hazelcast
+		return 0;
 	}
 	
 	private class Rule implements Comparable<Rule> {

--- a/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/internal/TasksDSComponent.java
+++ b/components/ntask/org.wso2.carbon.ntask.core/src/main/java/org/wso2/carbon/ntask/core/internal/TasksDSComponent.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.carbon.ntask.core.internal;
 
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.axis2.engine.ListenerManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -226,17 +225,6 @@ public class TasksDSComponent {
     protected void unsetSecretCallbackHandlerService(SecretCallbackHandlerService secretCallbackHandlerService) {
 
         TasksDSComponent.secretCallbackHandlerService = null;
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public static HazelcastInstance getHazelcastInstance() {
-
-        BundleContext ctx = FrameworkUtil.getBundle(TasksDSComponent.class).getBundleContext();
-        ServiceReference ref = ctx.getServiceReference(HazelcastInstance.class);
-        if (ref == null) {
-            return null;
-        }
-        return (HazelcastInstance) ctx.getService(ref);
     }
 
     @Reference(

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.orbit.com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>


### PR DESCRIPTION
## Purpose
As we have deprecated the Hazelcast based distributed caching use cases in APIM, removing the Hazelcast dependency from carbon-commons repository.

## Goals
Primary goal is to totally remove Hazelcast dependency from API Manager. In order to achieve that, we are removing Hazelcast from repositories such as,

1. Andes
2. Carbon Business Messaging
3. Carbon Event Processing
4. WSO2 Synapse
5. Carbon Mediation
6. Carbon Commons
7. Carbon Kernel
8. Siddhi

As API Manager is not using Hazelcast, and also was informed as during the effort of upgrading Hazelcast from 3.12.x to 4.2.x, the carbon-commons repository was not tracked as IS product dependent component, we are removing Hazelcast use-cases from Carbon Commons.

## Approach
NTask Core is using Hazelcast and since it is not possible to remove the whole component from Commons, removing Hazelcast within NTask is the approach. In addition to that, Also excluding Hazelcast from Carbon Kernel to ensure that it does not come from Kernel side. 

## Release note
Planning to release commons version which does not contain Hazelcast as release 4.9.x to avoid any possible conflicts.




