### PR TITLE
Remove clustering message passing logic as it will be sent via a different PR

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -113,12 +113,6 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         applyRemoteConfigurations(data, list, appenderName);
         applyConfigs();
         logAuditForConfigUpdate(url, appenderName);
-        if (!isPeriodicalSyncRequest) {
-            RemoteLoggingConfigDataHolder.getInstance().getClusterRemoteLoggerConfigInvalidationRequestSender()
-                    .send(true,
-                            CarbonContext.getThreadLocalCarbonContext().getTenantDomain(),
-                            CarbonContext.getThreadLocalCarbonContext().getTenantId());
-        }
     }
 
     private void logAuditForConfigUpdate(String url, String appenderName) {
@@ -164,12 +158,6 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         applyConfigs();
 
         logAuditForConfigReset(appenderName);
-        if (!isPeriodicalSyncRequest) {
-            RemoteLoggingConfigDataHolder.getInstance().getClusterRemoteLoggerConfigInvalidationRequestSender()
-                    .send(true,
-                            CarbonContext.getThreadLocalCarbonContext().getTenantDomain(),
-                            CarbonContext.getThreadLocalCarbonContext().getTenantId());
-        }
     }
 
     private void logAuditForConfigReset(String appenderName) {

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.logging.service.internal;
 
 import org.apache.axis2.clustering.ClusteringAgent;
 import org.wso2.carbon.logging.service.RemoteLoggingConfigService;
-import org.wso2.carbon.logging.service.clustering.ClusterRemoteLoggerConfigInvalidationRequestSender;
 import org.wso2.carbon.registry.core.service.RegistryService;
 
 /**
@@ -32,7 +31,6 @@ public class RemoteLoggingConfigDataHolder {
     private RegistryService registryService;
     private RemoteLoggingConfigService remoteLoggingConfigService;
     private ClusteringAgent clusteringAgent;
-    private ClusterRemoteLoggerConfigInvalidationRequestSender clusterRemoteLoggerConfigInvalidationRequestSender;
 
     private RemoteLoggingConfigDataHolder() {
 
@@ -77,16 +75,5 @@ public class RemoteLoggingConfigDataHolder {
     public void setClusteringAgent(ClusteringAgent clusteringAgent) {
 
         this.clusteringAgent = clusteringAgent;
-    }
-
-    public ClusterRemoteLoggerConfigInvalidationRequestSender getClusterRemoteLoggerConfigInvalidationRequestSender() {
-
-        return clusterRemoteLoggerConfigInvalidationRequestSender;
-    }
-
-    public void setClusterRemoteLoggerConfigInvalidationRequestSender(
-            ClusterRemoteLoggerConfigInvalidationRequestSender clusterRemoteLoggerConfigInvalidationRequestSender) {
-
-        this.clusterRemoteLoggerConfigInvalidationRequestSender = clusterRemoteLoggerConfigInvalidationRequestSender;
     }
 }

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigServiceComponent.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigServiceComponent.java
@@ -29,9 +29,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.logging.service.RemoteLoggingConfig;
 import org.wso2.carbon.logging.service.RemoteLoggingConfigService;
-import org.wso2.carbon.logging.service.clustering.ClusterRemoteLoggerConfigInvalidationRequestSender;
 import org.wso2.carbon.registry.core.service.RegistryService;
-import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.io.IOException;
 
@@ -51,10 +49,6 @@ public class RemoteLoggingConfigServiceComponent {
             componentContext.getBundleContext().registerService(
                     RemoteLoggingConfigService.class, remoteLoggingConfig, null);
             RemoteLoggingConfigDataHolder.getInstance().setRemoteLoggingConfigService(remoteLoggingConfig);
-            ClusterRemoteLoggerConfigInvalidationRequestSender clusterRemoteLoggerConfigInvalidationRequestSender =
-                    new ClusterRemoteLoggerConfigInvalidationRequestSender();
-            RemoteLoggingConfigDataHolder.getInstance().setClusterRemoteLoggerConfigInvalidationRequestSender(
-                    clusterRemoteLoggerConfigInvalidationRequestSender);
         } catch (IOException e) {
             LOG.error("IO exception occurred when creating RemoteLoggingConfig instance", e);
         }
@@ -89,23 +83,5 @@ public class RemoteLoggingConfigServiceComponent {
             LOG.debug("Unsetting the RegistryService");
         }
         RemoteLoggingConfigDataHolder.getInstance().setRegistryService(null);
-    }
-
-    @Reference(
-            name = "config.context.service",
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetClusteringAgent"
-    )
-    protected void setClusteringAgent(ConfigurationContextService configurationContextService) {
-
-        RemoteLoggingConfigDataHolder.getInstance()
-                .setClusteringAgent(configurationContextService.getServerConfigContext().getAxisConfiguration().
-                        getClusteringAgent());
-    }
-
-    protected void unsetClusteringAgent(ConfigurationContextService configurationContextService) {
-
-        RemoteLoggingConfigDataHolder.getInstance().setClusteringAgent(null);
     }
 }


### PR DESCRIPTION
## Purpose
- Remove remote logging clustering message passing related logic

## Related PRs
- https://github.com/wso2/carbon-commons/pull/478

## Related Issues:
- https://github.com/wso2/product-is/issues/16697
- https://github.com/wso2/api-manager/issues/1565