### PR TITLE
[4.9.x] Update version range for org.osgi.service.cm

### DIFF
--- a/components/logging/org.wso2.carbon.logging.updater/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.updater/pom.xml
@@ -44,7 +44,7 @@
                         <Import-Package>
                             !org.wso2.carbon.logging.updater.*,
                             org.wso2.carbon.utils.*;version="${carbon.kernel.imp.pkg.version}",
-                            org.osgi.service.cm.*,
+                            org.osgi.service.cm.*;version="${org.osgi.service.cm.version.range}",
                             org.osgi.service.component.*;version="${osgi.service.imp.pkg.version}",
                             *;resolution:=optional
                         </Import-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -1985,6 +1985,7 @@
         <pax.logging.api.version.range>[1.11.0,3.0.0)</pax.logging.api.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>
+        <org.osgi.service.cm.version.range>[1.3.100,2.0.0)</org.osgi.service.cm.version.range>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>
         <version.eclipse.equinox.event>1.5.100</version.eclipse.equinox.event>
         <commons.configuration.version>1.10</commons.configuration.version>


### PR DESCRIPTION
## Purpose

This PR updates the org.osgi.service.cm version range to [1.3.100, 2.0.0) in the org.wso2.carbon.logging.updater component.