### PR TITLE
[4.9.x] Revert the pax-logging version back to 1.11.0

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.upload/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.application.upload/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/caching-invalidator/org.wso2.carbon.caching.invalidator/pom.xml
+++ b/components/caching-invalidator/org.wso2.carbon.caching.invalidator/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.admin/pom.xml
+++ b/components/event/org.wso2.carbon.event.admin/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.client/pom.xml
+++ b/components/event/org.wso2.carbon.event.client/pom.xml
@@ -32,7 +32,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.common/pom.xml
+++ b/components/event/org.wso2.carbon.event.common/pom.xml
@@ -32,7 +32,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.core/pom.xml
+++ b/components/event/org.wso2.carbon.event.core/pom.xml
@@ -33,7 +33,7 @@
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.ui/pom.xml
+++ b/components/event/org.wso2.carbon.event.ui/pom.xml
@@ -31,7 +31,7 @@
     <url>http://wso2.org</url>
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/org.wso2.carbon.event.ws/pom.xml
+++ b/components/event/org.wso2.carbon.event.ws/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/event/pom.xml
+++ b/components/event/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
 

--- a/components/ganalytics/org.wso2.carbon.ganalytics.publisher/pom.xml
+++ b/components/ganalytics/org.wso2.carbon.ganalytics.publisher/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/ganalytics/pom.xml
+++ b/components/ganalytics/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/hostobjects/org.wso2.carbon.hostobjects.carbonutil/pom.xml
+++ b/components/hostobjects/org.wso2.carbon.hostobjects.carbonutil/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>js</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/hostobjects/org.wso2.carbon.hostobjects.sso/pom.xml
+++ b/components/hostobjects/org.wso2.carbon.hostobjects.sso/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>js</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <version>${pax.logging.api.version}</version>
         </dependency>

--- a/components/logging/org.wso2.carbon.logging.appender.http/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.appender.http/pom.xml
@@ -57,7 +57,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
-                        <Fragment-Host>org.wso2.org.ops4j.pax.logging.pax-logging-log4j2</Fragment-Host>
+                        <Fragment-Host>org.ops4j.pax.logging.pax-logging-log4j2</Fragment-Host>
                         <Export-Package>
                             org.wso2.carbon.logging.appender.*,
                         </Export-Package>

--- a/components/logging/org.wso2.carbon.logging.updater/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.updater/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/logging/org.wso2.carbon.logging.updater/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.updater/pom.xml
@@ -44,7 +44,7 @@
                         <Import-Package>
                             !org.wso2.carbon.logging.updater.*,
                             org.wso2.carbon.utils.*;version="${carbon.kernel.imp.pkg.version}",
-                            org.osgi.service.cm.*;version="${org.osgi.service.cm.version.range}",
+                            org.osgi.service.cm.*,
                             org.osgi.service.component.*;version="${osgi.service.imp.pkg.version}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/logging/org.wso2.carbon.logging.view/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.view/pom.xml
@@ -43,7 +43,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/logging/pom.xml
+++ b/components/logging/pom.xml
@@ -59,7 +59,7 @@
                 <artifactId>org.wso2.carbon.core</artifactId>
             </dependency>
             <dependency>
-                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+                <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
             </dependency>
             <dependency>

--- a/components/reporting/org.wso2.carbon.reporting.core/pom.xml
+++ b/components/reporting/org.wso2.carbon.reporting.core/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/reporting/org.wso2.carbon.reporting.util/pom.xml
+++ b/components/reporting/org.wso2.carbon.reporting.util/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.reporting.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+                <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
@@ -1981,7 +1981,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
         <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
-        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
+        <pax.logging.api.version>1.11.0</pax.logging.api.version>
         <pax.logging.api.version.range>[1.11.0,3.0.0)</pax.logging.api.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>

--- a/pom.xml
+++ b/pom.xml
@@ -1985,7 +1985,6 @@
         <pax.logging.api.version.range>[1.11.0,3.0.0)</pax.logging.api.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>
-        <org.osgi.service.cm.version.range>[1.3.100,2.0.0)</org.osgi.service.cm.version.range>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>
         <version.eclipse.equinox.event>1.5.100</version.eclipse.equinox.event>
         <commons.configuration.version>1.10</commons.configuration.version>

--- a/service-stubs/cluster-mgt/pom.xml
+++ b/service-stubs/cluster-mgt/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/event/pom.xml
+++ b/service-stubs/event/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/logging/pom.xml
+++ b/service-stubs/logging/pom.xml
@@ -76,7 +76,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
 

--- a/service-stubs/message-flows/pom.xml
+++ b/service-stubs/message-flows/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/ndatasource/org.wso2.carbon.ndatasource.stub/pom.xml
+++ b/service-stubs/ndatasource/org.wso2.carbon.ndatasource.stub/pom.xml
@@ -114,7 +114,7 @@
             </exclusions>
         </dependency>
 		<dependency>
-			<groupId>org.wso2.org.ops4j.pax.logging</groupId>
+			<groupId>org.ops4j.pax.logging</groupId>
 			<artifactId>pax-logging-api</artifactId>
 		</dependency>
 		<dependency>

--- a/service-stubs/org.wso2.carbon.adc.repositoryinformation.service.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.adc.repositoryinformation.service.stub/pom.xml
@@ -121,7 +121,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.application.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.application.mgt.stub/pom.xml
@@ -132,7 +132,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.deployment.synchronizer.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.deployment.synchronizer.stub/pom.xml
@@ -125,7 +125,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.discovery.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.discovery.stub/pom.xml
@@ -126,7 +126,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/org.wso2.carbon.identity.oauth.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.identity.oauth.stub/pom.xml
@@ -151,7 +151,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/service-stubs/remote-tasks/pom.xml
+++ b/service-stubs/remote-tasks/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/reporting/pom.xml
+++ b/service-stubs/reporting/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/soap-tracer/pom.xml
+++ b/service-stubs/soap-tracer/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/system-statistics/org.wso2.carbon.statistics.stub/pom.xml
+++ b/service-stubs/system-statistics/org.wso2.carbon.statistics.stub/pom.xml
@@ -131,7 +131,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/url-mapper/pom.xml
+++ b/service-stubs/url-mapper/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/service-stubs/wsdl-tools/org.wso2.carbon.wsdl2code.stub/pom.xml
+++ b/service-stubs/wsdl-tools/org.wso2.carbon.wsdl2code.stub/pom.xml
@@ -141,7 +141,7 @@
             <artifactId>XmlSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Purpose
This PR reverts back the pax-logging version back to 1.11.0