### PR TITLE
Add info log after log4j config updates

### DIFF
--- a/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LogConfigUpdater.java
+++ b/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LogConfigUpdater.java
@@ -80,7 +80,6 @@ public class LogConfigUpdater implements Runnable {
         Hashtable paxLoggingProperties = getPaxLoggingProperties();
         paxLoggingProperties.forEach(properties::put);
         configuration.update(properties);
-
     }
 
     private Hashtable getPaxLoggingProperties() throws IOException {

--- a/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LogConfigUpdater.java
+++ b/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/LogConfigUpdater.java
@@ -61,6 +61,7 @@ public class LogConfigUpdater implements Runnable {
                 if (modifiedTime.compareTo(lastModifiedTime) > 0) {
                     DataHolder.getInstance().setModifiedTime(modifiedTime);
                     updateLoggingConfiguration();
+                    LOG.info("Logging configuration applied successfully");
                 }
             }
         } catch (LoggingUpdaterException e) {
@@ -79,6 +80,7 @@ public class LogConfigUpdater implements Runnable {
         Hashtable paxLoggingProperties = getPaxLoggingProperties();
         paxLoggingProperties.forEach(properties::put);
         configuration.update(properties);
+
     }
 
     private Hashtable getPaxLoggingProperties() throws IOException {


### PR DESCRIPTION
## Purpose
This will fix https://github.com/wso2/api-manager/issues/2589

The issue has been introduced due to the pax logging upgrade in the product hence the log has to be added to the run() method where the changes will be monitored and applied

