### PR TITLE
Add error codes for tenant API

### DIFF
--- a/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
+++ b/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
@@ -56,7 +56,10 @@ public class TenantConstants {
         ERROR_CODE_TENANT_DOES_NOT_MATCH_REGEX_PATTERN("TM-60017", "Invalid tenant domain: %s. " +
                 "Domain should match the regex pattern %s."),
         ERROR_CODE_PRE_TENANT_CREATION_FAILED("TM-60018", "Error occurred in tenant pre creation."),
-        ERROR_CODE_TENANT_LIMIT_REACHED("TM-60019", "Maximum tenant limit reached.");
+        ERROR_CODE_TENANT_LIMIT_REACHED("TM-60019", "Maximum tenant limit reached."),
+        ERROR_CODE_OWNER_NOT_FOUND("TM-60020", "Tenant owner cannot be found for the provided id: %s."),
+        ERROR_CODE_PARTIALLY_CREATED_OR_UPDATED("TM-60021", "Tenant creation / update was successful " +
+                "with errors.");
 
         private final String code;
         private final String message;

--- a/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
+++ b/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
@@ -57,7 +57,7 @@ public class TenantConstants {
                 "Domain should match the regex pattern %s."),
         ERROR_CODE_PRE_TENANT_CREATION_FAILED("TM-60018", "Error occurred in tenant pre creation."),
         ERROR_CODE_TENANT_LIMIT_REACHED("TM-60019", "Maximum tenant limit reached."),
-        ERROR_CODE_OWNER_NOT_FOUND("TM-60020", "Tenant owner cannot be found for the provided id: %s."),
+        ERROR_CODE_OWNER_NOT_FOUND("TM-60020", "Tenant owner cannot be found for the provided tenant id: %s."),
         ERROR_CODE_PARTIALLY_CREATED_OR_UPDATED("TM-60021", "Tenant creation / update was completed " +
                 "with errors.");
 

--- a/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
+++ b/components/tenant-mgt-common/org.wso2.carbon.tenant.common/src/main/java/org/wso2/carbon/stratos/common/constants/TenantConstants.java
@@ -58,7 +58,7 @@ public class TenantConstants {
         ERROR_CODE_PRE_TENANT_CREATION_FAILED("TM-60018", "Error occurred in tenant pre creation."),
         ERROR_CODE_TENANT_LIMIT_REACHED("TM-60019", "Maximum tenant limit reached."),
         ERROR_CODE_OWNER_NOT_FOUND("TM-60020", "Tenant owner cannot be found for the provided id: %s."),
-        ERROR_CODE_PARTIALLY_CREATED_OR_UPDATED("TM-60021", "Tenant creation / update was successful " +
+        ERROR_CODE_PARTIALLY_CREATED_OR_UPDATED("TM-60021", "Tenant creation / update was completed " +
                 "with errors.");
 
         private final String code;


### PR DESCRIPTION
## Purpose
Introduce new error codes for tenant management API to handle following errors.
 - TM-60020: Owner id is not matching for the given tenant id 
 - TM-60021: Tenant is partially created / updated when provided claims fails validation. Related to https://github.com/wso2/product-is/issues/21346

## Related Issue
- https://github.com/wso2/product-is/issues/21271