### PR TITLE
Hiding remote log credentials from the UI and API

### DIFF
--- a/components/logging/org.wso2.carbon.logging.appender.http/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.appender.http/pom.xml
@@ -44,6 +44,10 @@
             <groupId>org.eclipse.osgi</groupId>
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.base</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/logging/org.wso2.carbon.logging.appender.http/src/main/java/org/wso2/carbon/logging/appender/http/utils/AppenderConstants.java
+++ b/components/logging/org.wso2.carbon.logging.appender.http/src/main/java/org/wso2/carbon/logging/appender/http/utils/AppenderConstants.java
@@ -32,4 +32,6 @@ public class AppenderConstants {
     public static final String QUEUE_DIRECTORY_PATH = "repository/logs/remotequeue";
     public static final int MINIMUM_BATCH_SIZE_IN_BYTES =  1024 * 256; // 256 KB
     public static final int MINIMUM_DISK_SPACE_IN_BYTES = 1024 * 1024 * 10; // 10 MB
+
+    public static final String REMOTE_LOGGING_HIDE_SECRETS = "RemoteLogging.HideSecrets";
 }

--- a/components/logging/org.wso2.carbon.logging.service/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.service/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.base</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingConstants.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingConstants.java
@@ -100,6 +100,8 @@ public final class LoggingConstants {
     public static final String CARBON = "CARBON";
     public static final String LOG_TYPE = "logType";
 
+    public static final String REMOTE_LOGGING_HIDE_SECRETS = "RemoteLogging.HideSecrets";
+
     public enum LogType {
         AUDIT,
         CARBON

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingConstants.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingConstants.java
@@ -101,6 +101,7 @@ public final class LoggingConstants {
     public static final String LOG_TYPE = "logType";
 
     public static final String REMOTE_LOGGING_HIDE_SECRETS = "RemoteLogging.HideSecrets";
+    public static final String REMOTE_LOGGING_ENABLE_ENCRYPTION = "RemoteLogging.EnableEncryption";
 
     public enum LogType {
         AUDIT,

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -145,8 +145,6 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         }
     }
 
-
-
     private void logAuditForConfigUpdate(String url, String appenderName) {
 
         Date currentTime = Calendar.getInstance().getTime();

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -221,14 +221,14 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         try {
             remoteServerConfig = RemoteLoggingConfigDataHolder.getInstance()
                     .getRemoteLoggingConfigDAO().getRemoteServerConfig(LogType.valueOf(logType));
-            remoteServerConfig.ifPresent(data -> {
-                if (!includeSecrets) {
-                    // If secrets are not to be included, clear the sensitive fields.
-                    data.setPassword(null);
-                    data.setKeystorePassword(null);
-                    data.setTruststorePassword(null);
-                }
-            });
+            if (remoteServerConfig.isPresent() && !includeSecrets) {
+                RemoteServerLoggerData data = remoteServerConfig.get();
+                // If secrets are not to be included, clear the sensitive fields.
+                data.setPassword(null);
+                data.setKeystorePassword(null);
+                data.setTruststorePassword(null);
+                return data;
+            }
             return remoteServerConfig.orElse(null);
         } catch (RemoteLoggingServerException e) {
             throw new ConfigurationException(e);

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -28,6 +28,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.logging.service.LoggingConstants.LogType;
 import org.wso2.carbon.logging.service.data.RemoteServerLoggerData;
 import org.wso2.carbon.logging.service.internal.RemoteLoggingConfigDataHolder;
@@ -39,6 +41,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -108,10 +111,41 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         }
         loadConfigs();
         ArrayList<String> list = Utils.getKeysOfAppender(logPropFile, appenderName);
+        encryptRemoteServerCredentials(data);
         applyRemoteConfigurations(data, list, appenderName);
         applyConfigs();
         logAuditForConfigUpdate(url, appenderName);
     }
+
+    private void encryptRemoteServerCredentials(RemoteServerLoggerData data) throws ConfigurationException {
+
+        data.setPassword(encryptRemoteServerCredential(data.getPassword()));
+        data.setKeystorePassword(encryptRemoteServerCredential(data.getKeystorePassword()));
+        data.setTruststorePassword(encryptRemoteServerCredential(data.getTruststorePassword()));
+    }
+
+    private String encryptRemoteServerCredential(String secretValue) throws ConfigurationException {
+
+        if (StringUtils.isBlank(secretValue)) {
+            return StringUtils.EMPTY;
+        }
+        if (secretValue.startsWith("$secret{") && secretValue.endsWith("}")) {
+            // If the secret is already encrypted using CipherTool, return it as is.
+            return secretValue;
+        }
+        if (!Boolean.parseBoolean(RemoteLoggingConfigDataHolder.getInstance().getServerConfigurationService()
+                .getFirstProperty(LoggingConstants.REMOTE_LOGGING_HIDE_SECRETS))) {
+            return secretValue;
+        }
+        try {
+            return CryptoUtil.getDefaultCryptoUtil()
+                    .encryptAndBase64Encode(secretValue.getBytes(StandardCharsets.UTF_8));
+        } catch (CryptoException e) {
+            throw new ConfigurationException("Error while adding the secret", e);
+        }
+    }
+
+
 
     private void logAuditForConfigUpdate(String url, String appenderName) {
 
@@ -173,6 +207,12 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     @Override
     public RemoteServerLoggerData getRemoteServerConfig(String logType) throws ConfigurationException {
 
+        return getRemoteServerConfig(logType, true);
+    }
+
+    @Override
+    public RemoteServerLoggerData getRemoteServerConfig(String logType, boolean includeSecrets) throws ConfigurationException {
+
         if (StringUtils.isBlank(logType)) {
             throw new ConfigurationException("Log type cannot be empty.");
         }
@@ -181,6 +221,14 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         try {
             remoteServerConfig = RemoteLoggingConfigDataHolder.getInstance()
                     .getRemoteLoggingConfigDAO().getRemoteServerConfig(LogType.valueOf(logType));
+            remoteServerConfig.ifPresent(data -> {
+                if (!includeSecrets) {
+                    // If secrets are not to be included, clear the sensitive fields.
+                    data.setPassword(null);
+                    data.setKeystorePassword(null);
+                    data.setTruststorePassword(null);
+                }
+            });
             return remoteServerConfig.orElse(null);
         } catch (RemoteLoggingServerException e) {
             throw new ConfigurationException(e);
@@ -232,12 +280,18 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     @Override
     public List<RemoteServerLoggerData> getRemoteServerConfigs() throws ConfigurationException {
 
+        return getRemoteServerConfigs(true);
+    }
+
+    @Override
+    public List<RemoteServerLoggerData> getRemoteServerConfigs(boolean includeSecrets) throws ConfigurationException {
+
         List<String> logTypes = new ArrayList<>();
         logTypes.add(LoggingConstants.AUDIT);
         logTypes.add(LoggingConstants.CARBON);
         List<RemoteServerLoggerData> remoteServerLoggerDataList = new ArrayList<>();
         for (String logType : logTypes) {
-            RemoteServerLoggerData remoteServerLoggerData = getRemoteServerConfig(logType);
+            RemoteServerLoggerData remoteServerLoggerData = getRemoteServerConfig(logType, includeSecrets);
             if (remoteServerLoggerData != null) {
                 remoteServerLoggerDataList.add(remoteServerLoggerData);
             }

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
@@ -77,6 +77,18 @@ public interface RemoteLoggingConfigService {
     List<RemoteServerLoggerData> getRemoteServerConfigs() throws ConfigurationException;
 
     /**
+     * This method is used to get the remote server configurations.
+     * @param includeSecrets  Boolean value to indicate whether to include secrets in the response or not.
+     *
+     * @return List of RemoteServerLoggerData objects that contains the remote server configurations.
+     * @throws ConfigurationException   If an error occurs while loading the log4j2.properties file.
+     */
+    default List<RemoteServerLoggerData> getRemoteServerConfigs(boolean includeSecrets) throws ConfigurationException {
+
+        return getRemoteServerConfigs();
+    }
+
+    /**
      * This method is used to get the remote server configuration for a given log type.
      * @param logType  The log type of the remote server configuration.
      * @return RemoteServerLoggerData object that contains the remote server configuration.
@@ -84,6 +96,20 @@ public interface RemoteLoggingConfigService {
      */
     RemoteServerLoggerData getRemoteServerConfig(String logType)
             throws ConfigurationException;
+
+    /**
+     * This method is used to get the remote server configuration for a given log type.
+     * @param logType  The log type of the remote server configuration.
+     * @param includeSecrets  Boolean value to indicate whether to include secrets in the response or not.
+     *
+     * @return RemoteServerLoggerData object that contains the remote server configuration.
+     * @throws ConfigurationException If an error occurs while loading the log4j2.properties file.
+     */
+    default RemoteServerLoggerData getRemoteServerConfig(String logType, boolean includeSecrets)
+            throws ConfigurationException{
+
+        return getRemoteServerConfig(logType);
+    }
 
     /**
      * This method is used to sync the remote server configurations with the remote server.

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/dao/impl/RegistryBasedRemoteLoggingConfigDAO.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/dao/impl/RegistryBasedRemoteLoggingConfigDAO.java
@@ -19,6 +19,9 @@
 package org.wso2.carbon.logging.service.dao.impl;
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.logging.service.LoggingConstants;
 import org.wso2.carbon.logging.service.LoggingConstants.LogType;
 import org.wso2.carbon.logging.service.RemoteLoggingServerException;
@@ -30,6 +33,7 @@ import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.jdbc.utils.Transaction;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 /**
@@ -116,21 +120,60 @@ public class RegistryBasedRemoteLoggingConfigDAO implements RemoteLoggingConfigD
     }
 
     private Resource getResourceFromRemoteServerLoggerData(RemoteServerLoggerData data, Registry registry,
-                                                           LogType logType) throws RegistryException {
+                                                           LogType logType)
+            throws RegistryException, ConfigurationException {
 
         Resource resource = registry.newResource();
         resource.addProperty(LoggingConstants.URL, data.getUrl());
         resource.addProperty(LoggingConstants.USERNAME, data.getUsername());
-        resource.addProperty(LoggingConstants.PASSWORD, data.getPassword());
+        resource.addProperty(LoggingConstants.PASSWORD,
+                getEncryptedSecret(data.getPassword(), LoggingConstants.PASSWORD));
         resource.addProperty(LoggingConstants.KEYSTORE_LOCATION, data.getKeystoreLocation());
-        resource.addProperty(LoggingConstants.KEYSTORE_PASSWORD, data.getKeystorePassword());
+        resource.addProperty(LoggingConstants.KEYSTORE_PASSWORD,
+                getEncryptedSecret(data.getKeystorePassword(), LoggingConstants.KEYSTORE_PASSWORD));
         resource.addProperty(LoggingConstants.TRUSTSTORE_LOCATION, data.getTruststoreLocation());
-        resource.addProperty(LoggingConstants.TRUSTSTORE_PASSWORD, data.getTruststorePassword());
+        resource.addProperty(LoggingConstants.TRUSTSTORE_PASSWORD,
+                getEncryptedSecret(data.getTruststorePassword(), LoggingConstants.TRUSTSTORE_PASSWORD));
         resource.addProperty(LoggingConstants.VERIFY_HOSTNAME, String.valueOf(data.isVerifyHostname()));
         resource.addProperty(LoggingConstants.LOG_TYPE, logType.toString());
         resource.addProperty(LoggingConstants.CONNECT_TIMEOUT_MILLIS, data.getConnectTimeoutMillis());
         resource.addProperty(LoggingConstants.CONNECTION_TIMEOUT, data.getConnectTimeoutMillis());
         return resource;
+    }
+
+    private String getEncryptedSecret(String secretValue, String name) throws  ConfigurationException {
+
+        if (StringUtils.isBlank(secretValue)) {
+            return StringUtils.EMPTY;
+        }
+        if (!Boolean.parseBoolean(RemoteLoggingConfigDataHolder.getInstance().getServerConfigurationService()
+                .getFirstProperty(LoggingConstants.REMOTE_LOGGING_ENABLE_ENCRYPTION))) {
+            return secretValue;
+        }
+        try {
+            return CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
+                    secretValue.getBytes(StandardCharsets.UTF_8));
+        } catch (CryptoException e) {
+            throw new ConfigurationException("Error while adding the secret : " + name, e);
+        }
+    }
+
+    private String getDecryptedSecret(Resource resource, String name) {
+
+        String secretValue = resource.getProperty(name);
+        if (StringUtils.isBlank(secretValue)) {
+            return StringUtils.EMPTY;
+        }
+        if (!Boolean.parseBoolean(RemoteLoggingConfigDataHolder.getInstance().getServerConfigurationService()
+                .getFirstProperty(LoggingConstants.REMOTE_LOGGING_ENABLE_ENCRYPTION))) {
+            return secretValue;
+        }
+        try {
+            return new String(CryptoUtil.getDefaultCryptoUtil().base64DecodeAndDecrypt(
+                    secretValue), StandardCharsets.UTF_8);
+        } catch (CryptoException e) {
+            return secretValue;
+        }
     }
 
     private RemoteServerLoggerData getRemoteServerLoggerDataFromResource(Resource resource) {
@@ -139,11 +182,11 @@ public class RegistryBasedRemoteLoggingConfigDAO implements RemoteLoggingConfigD
         data.setUrl(resource.getProperty(LoggingConstants.URL));
         data.setConnectTimeoutMillis(resource.getProperty(LoggingConstants.CONNECTION_TIMEOUT));
         data.setUsername(resource.getProperty(LoggingConstants.USERNAME));
-        data.setPassword(resource.getProperty(LoggingConstants.PASSWORD));
+        data.setPassword(getDecryptedSecret(resource, LoggingConstants.PASSWORD));
         data.setKeystoreLocation(resource.getProperty(LoggingConstants.KEYSTORE_LOCATION));
-        data.setKeystorePassword(resource.getProperty(LoggingConstants.KEYSTORE_PASSWORD));
+        data.setKeystorePassword(getDecryptedSecret(resource, LoggingConstants.KEYSTORE_PASSWORD));
         data.setTruststoreLocation(resource.getProperty(LoggingConstants.TRUSTSTORE_LOCATION));
-        data.setTruststorePassword(resource.getProperty(LoggingConstants.TRUSTSTORE_PASSWORD));
+        data.setTruststorePassword(getDecryptedSecret(resource, LoggingConstants.TRUSTSTORE_PASSWORD));
         data.setVerifyHostname(Boolean.parseBoolean(resource.getProperty(LoggingConstants.VERIFY_HOSTNAME)));
         data.setLogType(resource.getProperty(LoggingConstants.LOG_TYPE));
         return data;

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.logging.service.internal;
 
 import org.apache.axis2.clustering.ClusteringAgent;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.logging.service.RemoteLoggingConfigService;
 import org.wso2.carbon.logging.service.dao.RemoteLoggingConfigDAO;
 import org.wso2.carbon.logging.service.dao.impl.RegistryBasedRemoteLoggingConfigDAO;
@@ -35,6 +36,7 @@ public class RemoteLoggingConfigDataHolder {
     private ClusteringAgent clusteringAgent;
     private RemoteLoggingConfigDAO remoteLoggingConfigDAO;
     private RemoteLoggingConfigDAO defaultRemoteLoggingConfigDAO = new RegistryBasedRemoteLoggingConfigDAO();
+    private ServerConfigurationService serverConfigurationService;
 
     private RemoteLoggingConfigDataHolder() {
 
@@ -92,5 +94,16 @@ public class RemoteLoggingConfigDataHolder {
     public void setRemoteLoggingConfigDAO(RemoteLoggingConfigDAO remoteLoggingConfigDAO) {
 
         this.remoteLoggingConfigDAO = remoteLoggingConfigDAO;
+    }
+
+
+    public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    public ServerConfigurationService getServerConfigurationService() {
+
+        return serverConfigurationService;
     }
 }

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigDataHolder.java
@@ -96,7 +96,6 @@ public class RemoteLoggingConfigDataHolder {
         this.remoteLoggingConfigDAO = remoteLoggingConfigDAO;
     }
 
-
     public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
 
         this.serverConfigurationService = serverConfigurationService;

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigServiceComponent.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/internal/RemoteLoggingConfigServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.logging.service.RemoteLoggingConfig;
 import org.wso2.carbon.logging.service.RemoteLoggingConfigService;
 import org.wso2.carbon.logging.service.dao.RemoteLoggingConfigDAO;
@@ -98,5 +99,28 @@ public class RemoteLoggingConfigServiceComponent {
 
         LOG.debug("Unsetting the RemoteLoggingConfigDAO");
         RemoteLoggingConfigDataHolder.getInstance().setRemoteLoggingConfigDAO(null);
+    }
+
+    @Reference(
+            name = "server.configuration.service",
+            service = org.wso2.carbon.base.api.ServerConfigurationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetServerConfigurationService"
+    )
+    protected void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting the ServerConfigurationService");
+        }
+        RemoteLoggingConfigDataHolder.getInstance().setServerConfigurationService(serverConfigurationService);
+    }
+
+    protected void unsetServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Unsetting the ServerConfigurationService");
+        }
+        RemoteLoggingConfigDataHolder.getInstance().setServerConfigurationService(null);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,11 @@
                 <artifactId>org.wso2.carbon.server.admin</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.base</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.server</artifactId>


### PR DESCRIPTION
- Added new methods to get remote server credentials without the secrets
- Encrypt the secrets added to the log4j.properties file

```toml
[remote_logging]
hide_secrets=true
```