### PR TITLE
Update dependency versions

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/pom.xml
+++ b/components/logging/org.wso2.carbon.logging.service/pom.xml
@@ -49,9 +49,9 @@
                         <Import-Package>
                             !org.wso2.carbon.logging.service.*;version="4.3.0",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
-                            org.apache.commons.logging,
+                            org.apache.commons.logging;version="${commons-logging.version.range}",
                             org.osgi.service.cm;version="${version.eclipse.equinox.cm}",
-                            org.apache.commons.configuration;version="${commons.configuration.version}",
+                            org.apache.commons.configuration2.*;version="${commons-configuration.version.range}",
                             *;resolution:=optional,
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
@@ -83,9 +83,8 @@
             <artifactId>spring.framework</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>${commons.configuration.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingAdmin.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/LoggingAdmin.java
@@ -19,9 +19,9 @@
 
 package org.wso2.carbon.logging.service;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.configuration.PropertiesConfigurationLayout;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfigurationLayout;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -133,12 +133,12 @@ public class LoggingAdmin {
 
     private void loadConfigs() throws FileNotFoundException, ConfigurationException {
         config = new PropertiesConfiguration();
-        layout = new PropertiesConfigurationLayout(config);
-        layout.load(new InputStreamReader(new FileInputStream(logPropFile)));
+        layout = new PropertiesConfigurationLayout();
+        layout.load(config, new InputStreamReader(new FileInputStream(logPropFile)));
     }
 
     private void applyConfigs() throws IOException, ConfigurationException {
-        layout.save(new FileWriter(filePath, false));
+        layout.save(config, new FileWriter(filePath, false));
     }
 
     public boolean isLoggerExist(String loggerName) throws IOException {

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -19,9 +19,9 @@
 
 package org.wso2.carbon.logging.service;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.configuration.PropertiesConfigurationLayout;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfigurationLayout;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -71,8 +71,8 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     private void loadConfigs() throws IOException, ConfigurationException {
 
         config = new PropertiesConfiguration();
-        layout = new PropertiesConfigurationLayout(config);
-        layout.load(new InputStreamReader(new FileInputStream(logPropFile)));
+        layout = new PropertiesConfigurationLayout();
+        layout.load(config, new InputStreamReader(new FileInputStream(logPropFile)));
     }
 
     /**
@@ -473,7 +473,7 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
 
     private void applyConfigs() throws IOException, ConfigurationException {
 
-        layout.save(new FileWriter(filePath, false));
+        layout.save(config, new FileWriter(filePath, false));
     }
 
     private void updateRemoteServerConfigInRegistry(RemoteServerLoggerData data, String appenderName)

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.logging.service;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.wso2.carbon.logging.service.data.RemoteServerLoggerData;
 
 import java.io.IOException;

--- a/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/RemoteLoggingConfigUpdater.java
+++ b/components/logging/org.wso2.carbon.logging.updater/src/main/java/org/wso2/carbon/logging/updater/RemoteLoggingConfigUpdater.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.logging.updater;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;

--- a/components/reporting/org.wso2.carbon.reporting.template.core/pom.xml
+++ b/components/reporting/org.wso2.carbon.reporting.template.core/pom.xml
@@ -26,11 +26,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-             <dependency>
-                  <groupId>commons-logging</groupId>
-                  <artifactId>commons-logging</artifactId>
-                  <version>1.1.1</version>
-              </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
           <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.core</artifactId>

--- a/features/logging-mgt/org.wso2.carbon.logging.mgt.feature/pom.xml
+++ b/features/logging-mgt/org.wso2.carbon.logging.mgt.feature/pom.xml
@@ -76,7 +76,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.logging.service:${carbon.commons.version}</bundleDef>
-                                <bundleDef>commons-configuration:commons-configuration:${commons.configuration.version}</bundleDef>
+                                <bundleDef>org.apache.commons:commons-configuration2:${commons-configuration.version}</bundleDef>
                             </bundles>
                             <includedFeatures>
                                 <includedFeatureDef>

--- a/features/logging-mgt/org.wso2.carbon.logging.remote.config.mgt.feature/pom.xml
+++ b/features/logging-mgt/org.wso2.carbon.logging.remote.config.mgt.feature/pom.xml
@@ -71,8 +71,8 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
+                                <bundleDef>org.apache.commons:commons-configuration2:${commons-configuration.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.logging.service:${carbon.commons.version}</bundleDef>
-                                <bundleDef>commons-configuration:commons-configuration:${commons.configuration.version}</bundleDef>
                             </bundles>
                             <includedFeatures>
                                 <includedFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,11 @@
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>commons-lang.wso2</groupId>
@@ -338,9 +343,10 @@
                 <artifactId>commons-httpclient</artifactId>
                 <version>${orbit.version.commons.httpclient}</version>
             </dependency>
+
             <dependency>
-                <groupId>commons-configuration.wso2</groupId>
-                <artifactId>commons-configuration</artifactId>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
                 <version>${commons-configuration.version}</version>
             </dependency>
 
@@ -1840,7 +1846,7 @@
         <libthrift.wso2.imp.pkg.version.range>[0.9.2.wso2v1,1.0.0]</libthrift.wso2.imp.pkg.version.range>
 
         <!-- JSON Version -->
-        <orbit.version.json>2.0.0.wso2v1</orbit.version.json>
+        <orbit.version.json>3.0.0.wso2v7</orbit.version.json>
 
         <!-- Validate Utility Version -->
         <validateutility.version>0.95</validateutility.version>
@@ -1851,27 +1857,26 @@
 
         <!-- Commons Version -->
         <commons.pool.version>1.5.0.wso2v1</commons.pool.version>
-        <commons-logging.version>1.1.1</commons-logging.version>
+        <commons-logging.version>1.3.5</commons-logging.version>
+        <commons-logging.version.range>[1.0.0,2.0.0)</commons-logging.version.range>
         <commons-logging.imp.pkg.version>0.0.0</commons-logging.imp.pkg.version>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.httpclient>3.1.0.wso2v6</orbit.version.commons.httpclient>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <orbit.version.commons.codec>1.4.0.wso2v1</orbit.version.commons.codec>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-digester.version>1.8</commons-digester.version>
         <orbit.version.backport.util>3.1.0.wso2v1</orbit.version.backport.util>
-        <version.commons.lang3>3.1</version.commons.lang3>
+        <version.commons.lang3>3.18.0</version.commons.lang3>
         <commons-pool.version>1.5.0.wso2v1</commons-pool.version>
-        <commons-logging.version>1.1</commons-logging.version>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
-        <commons-collections.version>3.2</commons-collections.version>
         <commons-digester.version>1.8</commons-digester.version>
         <commons-dbcp.version>1.2.2</commons-dbcp.version>
-        <commons-fileupload.version>1.1.1</commons-fileupload.version>
+        <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-io.wso2.version>2.0.0.wso2v1</commons-io.wso2.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons.digester.wso2.version>1.8.1.wso2v1</commons.digester.wso2.version>
-        <commons-fileupload.wso2.version>1.2.2.wso2v1</commons-fileupload.wso2.version>
+        <commons-fileupload.wso2.version>1.6.0.wso2v1</commons-fileupload.wso2.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <osgi.framework.imp.pkg.version>[1.7.0,2.0.0)</osgi.framework.imp.pkg.version>
         <osgi.service.imp.pkg.version>[1.2.0,1.3.0)</osgi.service.imp.pkg.version>
@@ -1962,7 +1967,8 @@
         <perf4j.version>0.9.12.wso2v1</perf4j.version>
         <highscale.version>1.1.2.wso2v1</highscale.version>
         <antlr.version>3.2.0.wso2v1</antlr.version>
-        <commons-configuration.version>1.6.0.wso2v1</commons-configuration.version>
+        <commons-configuration.version>2.12.0</commons-configuration.version>
+        <commons-configuration.version.range>[2.2,3.0.0)</commons-configuration.version.range>
         <itext.wso2.version>2.1.7.wso2v1</itext.wso2.version>
         <jcommon.wso2.version>1.0.15.wso2v1</jcommon.wso2.version>
         <jasper.jdt.wso2.version>6.0.18.wso2v1</jasper.jdt.wso2.version>
@@ -1987,7 +1993,6 @@
         <import.package.version.apache.logging.log4j>[2.12.4,3.0.0)</import.package.version.apache.logging.log4j>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>
         <version.eclipse.equinox.event>1.5.100</version.eclipse.equinox.event>
-        <commons.configuration.version>1.10</commons.configuration.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This pull request upgrades the logging service and related modules to use `commons-configuration2` instead of the legacy `commons-configuration` library, and updates several dependency versions for improved compatibility and security. The changes touch multiple Maven POM files and Java source files, ensuring consistent usage of the new library across the codebase. Additionally, several other library versions are updated to more recent releases.

**Migration to commons-configuration2:**

* Replaced all usages and imports of `commons-configuration` with `commons-configuration2` in Java source files such as `LoggingAdmin.java`, `RemoteLoggingConfig.java`, `RemoteLoggingConfigService.java`, and `RemoteLoggingConfigUpdater.java`. [[1]](diffhunk://#diff-994083fedcfdd11250fd641717834cc03e76533e31cde343f9b03e21575633e8L22-R24) [[2]](diffhunk://#diff-0ea4376d34e6127ed7ccf380c66fd868d0893764280e37c0fd739ac11a3fbcc3L22-R24) [[3]](diffhunk://#diff-448dd242fb4deb639c4bbbd7e4a0b3baa258d7fc09ded5a4fce0ba9e886f781eL21-R21) [[4]](diffhunk://#diff-a06a649c553b45b9f21525c2dec3996b31b2743dc644f18f7296906caa8b56d2L21-R21)
* Updated Maven dependencies in `pom.xml` and feature POMs to use `org.apache.commons:commons-configuration2` instead of `commons-configuration:commons-configuration`. [[1]](diffhunk://#diff-2f79239e3b4f4faf3563d66aedb333e95315b825a3b0db60e75698c9ca486b5cL86-R87) [[2]](diffhunk://#diff-4b578068ac8f4ebb63adf0cb89a6adc18cdb67552d5d094883658fac2f8a3b3aL79-R79) [[3]](diffhunk://#diff-be49d6c9c19faa351af6d7e45f77a81941c3ba0e3a7ac14c7b4e0134ea4159fbR74-L75) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R346-R349)
* Modified OSGi package imports to reference `org.apache.commons.configuration2.*` and updated version ranges accordingly.

**Dependency and version updates:**

* Upgraded several dependency versions, including `commons-logging` (to 1.3.5), `commons-collections` (to 3.2.2), `commons-beanutils` (to 1.11.0), `commons-fileupload` (to 1.6.0), and `commons-configuration` (to 2.12.0), and updated their version ranges. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L1843-R1849) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L1854-R1879) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L1965-R1971)
* Updated the JSON library version from `2.0.0.wso2v1` to `3.0.0.wso2v7` for improved compatibility.

**Code adjustments for new library API:**

* Refactored code in `LoggingAdmin.java` and `RemoteLoggingConfig.java` to use the updated API for loading and saving configuration files with `PropertiesConfigurationLayout` from `commons-configuration2`. [[1]](diffhunk://#diff-994083fedcfdd11250fd641717834cc03e76533e31cde343f9b03e21575633e8L136-R141) [[2]](diffhunk://#diff-0ea4376d34e6127ed7ccf380c66fd868d0893764280e37c0fd739ac11a3fbcc3L74-R75) [[3]](diffhunk://#diff-0ea4376d34e6127ed7ccf380c66fd868d0893764280e37c0fd739ac11a3fbcc3L476-R476)

**Build and packaging improvements:**

* Added missing dependency declarations for `commons-logging` and `commons-configuration2` in root and module POM files to ensure proper build and packaging. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R229-R233) [[2]](diffhunk://#diff-98f0d8abdbae1bec44b54d1e8cd569b755040889a2b2078a62f62dfe9bf44ef8L32)

These changes modernize the logging infrastructure, improve maintainability, and lay the groundwork for future enhancements.