### PR TITLE
Fix NPE in Axis2 RPC dispatch for remote logging config methods

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -86,13 +86,6 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     }
 
     @Override
-    public void addRemoteServerConfig(RemoteServerLoggerData data, boolean isPeriodicalSyncRequest)
-            throws IOException, ConfigurationException {
-
-        addRemoteServerConfig(data, Boolean.valueOf(isPeriodicalSyncRequest));
-    }
-
-    @Override
     public void addRemoteServerConfig(RemoteServerLoggerData data, Boolean isPeriodicalSyncRequest)
             throws IOException, ConfigurationException {
 
@@ -301,12 +294,6 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     public void resetRemoteServerConfig(RemoteServerLoggerData data) throws IOException, ConfigurationException {
 
         resetRemoteServerConfig(data, false);
-    }
-
-    public void resetRemoteServerConfig(RemoteServerLoggerData data, boolean isPeriodicalSyncRequest)
-            throws IOException, ConfigurationException {
-
-        resetRemoteServerConfig(data, Boolean.valueOf(isPeriodicalSyncRequest));
     }
 
     @Override

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfigService.java
@@ -46,16 +46,6 @@ public interface RemoteLoggingConfigService {
      * @throws IOException              If an error occurs while writing to the log4j2.properties file.
      * @throws ConfigurationException   If an error occurs while loading the log4j2.properties file.
      */
-    void addRemoteServerConfig(RemoteServerLoggerData data, boolean isPeriodicalSyncRequest) throws IOException, ConfigurationException;
-
-    /**
-     * This method is used to add a remote server configuration.
-     *
-     * @param data                      RemoteServerLoggerData object that contains the remote server configuration.
-     * @param isPeriodicalSyncRequest   Boolean value to indicate whether the request is a periodical sync request or not.
-     * @throws IOException              If an error occurs while writing to the log4j2.properties file.
-     * @throws ConfigurationException   If an error occurs while loading the log4j2.properties file.
-     */
     void addRemoteServerConfig(RemoteServerLoggerData data, Boolean isPeriodicalSyncRequest) throws IOException, ConfigurationException;
 
     /**
@@ -66,16 +56,6 @@ public interface RemoteLoggingConfigService {
      * @throws ConfigurationException   If an error occurs while loading the log4j2.properties file.
      */
     void resetRemoteServerConfig(RemoteServerLoggerData data) throws IOException, ConfigurationException;
-
-    /**
-     * This method is used to reset the remote server configurations to the defaults.
-     *
-     * @param data                      RemoteServerLoggerData object that contains the remote server configuration.
-     * @param isPeriodicalSyncRequest   Boolean value to indicate whether the request is a periodical sync request or not.
-     * @throws IOException              If an error occurs while writing to the log4j2.properties file.
-     * @throws ConfigurationException   If an error occurs while loading the log4j2.properties file.
-     */
-    void resetRemoteServerConfig(RemoteServerLoggerData data, boolean isPeriodicalSyncRequest) throws IOException, ConfigurationException;
 
     /**
      * This method is used to reset the remote server configurations to the defaults.


### PR DESCRIPTION
## Root Problem
When isPeriodicalSyncRequest is absent in the incoming SOAP/XML request payload, Axis2 RPC deserializes it as null and attempts to invoke addRemoteServerConfig / resetRemoteServerConfig via reflection. Since the parameter type was boolean (primitive), unboxing null to boolean throws a NullPointerException:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Number.intValue()" 
because the return value of "sun.invoke.util.ValueConversions.primitiveConversion(...)" is null
    at sun.invoke.util.ValueConversions.unboxBoolean
    at org.apache.axis2.rpc.receivers.RPCUtil.invokeServiceClass
```
- original issue : https://github.com/wso2/api-manager/issues/4748
- this was addressed in PR : https://github.com/wso2/carbon-commons/pull/549

## Problem with the above changes 

The prev fix added a Boolean overload alongside the original boolean method, keeping both in the interface and implementation.

But Java overload resolution picks the exact match ; when Axis2 resolves the method via reflection (Class.getMethods()), it still finds and invokes the boolean version for normal calls. The Boolean overload is never reached by Axis2.

## Fix 

Remove old method with boolean as parameter.

## Backward Compatibility

No impact on existing callers as Java auto-boxing transparently converts boolean literals/variables to Boolean at the call site. 

### **!!! Breaking change** 
The only breaking change would be for external implementors of RemoteLoggingConfigService, which uses old method signature. Need to update them with the new one.