### PR TITLE
Reset the remote logging configs when remote logging is enabled

### DIFF
--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/RemoteLoggingConfig.java
@@ -239,7 +239,7 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
     /**
      * Encrypts remote server credentials for storage in log4j2.properties.
      * Encryption is controlled by REMOTE_LOGGING_HIDE_SECRETS flag.
-     * 
+     *
      * @param data RemoteServerLoggerData containing credentials to encrypt for log4j2.properties
      * @throws ConfigurationException if encryption fails when HIDE_SECRETS is enabled
      */
@@ -252,7 +252,7 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
 
     /**
      * Encrypts credentials for storage in log4j2.properties based on HIDE_SECRETS flag.
-     * 
+     *
      * @param secretValue the credential to potentially encrypt
      * @return encrypted credential if HIDE_SECRETS=true, plain text if HIDE_SECRETS=false
      * @throws ConfigurationException if encryption fails when HIDE_SECRETS is enabled
@@ -600,7 +600,7 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
 
     /**
      * Encrypts credentials for Registry storage based on ENABLE_ENCRYPTION flag.
-     * 
+     *
      * @param secretValue the credential to potentially encrypt
      * @param name the name of the credential for error reporting
      * @return encrypted credential if ENABLE_ENCRYPTION=true, plain text if ENABLE_ENCRYPTION=false
@@ -625,7 +625,7 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
 
     /**
      * Decrypts credentials from Registry storage based on ENABLE_ENCRYPTION flag.
-     * 
+     *
      * @param resource the Registry resource containing the credential
      * @param name the name of the credential property
      * @return decrypted credential if ENABLE_ENCRYPTION=true, plain text if ENABLE_ENCRYPTION=false
@@ -766,7 +766,10 @@ public class RemoteLoggingConfig implements RemoteLoggingConfigService {
         for (RemoteServerLoggerData remoteServerLoggerData : dataList) {
             try {
                 if (isReset) {
-                    resetRemoteServerConfig(remoteServerLoggerData, true);
+                    String url = remoteServerLoggerData.getUrl();
+                    if (StringUtils.isNotBlank(url)) {
+                        resetRemoteServerConfig(remoteServerLoggerData, true);
+                    }
                 } else {
                     addRemoteServerConfig(remoteServerLoggerData, true);
                 }

--- a/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/util/Log4j2PropertiesEditor.java
+++ b/components/logging/org.wso2.carbon.logging.service/src/main/java/org/wso2/carbon/logging/service/util/Log4j2PropertiesEditor.java
@@ -41,6 +41,7 @@ public final class Log4j2PropertiesEditor {
     private static final Log log = LogFactory.getLog(Log4j2PropertiesEditor.class);
 
     private static final String APPENDER_PREFIX = "appender.";
+    private static final String APPENDER_LIST_KEY = "appenders";
     private static final String KV_SEPARATOR = "=";
 
     private Log4j2PropertiesEditor() {
@@ -260,7 +261,46 @@ public final class Log4j2PropertiesEditor {
         }
 
         lines.addAll(insertionIndex, toInsert);
+        addAppenderToAppendersList(lines, appenderName);
         writeLinesAtomically(file.toPath(), lines);
+    }
+
+    /**
+     * Ensures the given appender name is present in the {@code appenders} list property.
+     * If the property does not exist, it is appended at the end of the lines.
+     * If the appender is already listed, the lines are left unchanged.
+     *
+     * @param lines the current lines of the properties file (modified in place)
+     * @param appenderName the appender name to add
+     */
+    private static void addAppenderToAppendersList(ArrayList<String> lines, String appenderName) {
+        for (int i = 0; i < lines.size(); i++) {
+            String trimmed = lines.get(i).trim();
+            if (trimmed.isEmpty() || isCommentLine(trimmed)) {
+                continue;
+            }
+            int sep = findKeyValueSeparator(trimmed);
+            if (sep <= 0) {
+                continue;
+            }
+            String key = trimmed.substring(0, sep).trim();
+            if (key.equals(APPENDER_LIST_KEY)) {
+                String value = trimmed.substring(sep + 1).trim();
+                // Check if already listed (comma-separated)
+                String[] parts = value.split(",");
+                for (String part : parts) {
+                    if (part.trim().equals(appenderName)) {
+                        return; // already present, nothing to do
+                    }
+                }
+                // Append the new appender name
+                String newValue = value.isEmpty() ? appenderName : appenderName + ", " + value;
+                lines.set(i, key + " = " + newValue);
+                return;
+            }
+        }
+        // Property not found; add it at the end
+        lines.add(APPENDER_LIST_KEY + " = " + appenderName);
     }
 
     private static int getInsertionIndex(ArrayList<String> lines, int originalFirstIdx) {


### PR DESCRIPTION
### Description
This pull request introduces optimizations to the logging configuration handling do avoid adding the `AUDIT`, `CARBON` and `API` appenders unnecessarily when remote logging is disabled. Furthermore, this improves consistency of appenders to avoid dangling appender references.

Related to - https://github.com/wso2/api-manager/issues/4925

### Approach
The main changes enhance how appenders are added to the Log4j2 properties and improve the safety of resetting remote server configurations.

Remote logging configuration robustness:
* Updated `processRemoteServerLoggerData` in `RemoteLoggingConfig.java` to check that the remote server URL is not blank before attempting to reset the remote server configuration, preventing unnecessary or invalid reset operations.

Appender management improvements:
* Added logic in `Log4j2PropertiesEditor` to ensure that when a new appender is written using `writeUpdatedAppender`, it is also included in the `appenders` list property if not already present. This prevents dangling appenders where an appender exists but is not referenced in the appender list. [[1]](diffhunk://#diff-74fc44fa9059121c4ab1188d7422e8b2d5dea6f0bd96c418d647bdc095be8b25R44) [[2]](diffhunk://#diff-74fc44fa9059121c4ab1188d7422e8b2d5dea6f0bd96c418d647bdc095be8b25R264-R305)
* Introduced the `addAppenderToAppendersList` helper method to handle updating or adding the `appenders` property in the properties file.